### PR TITLE
feat: add age.files for arbitrary file encryption/decryption

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -1,12 +1,10 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/hay-kot/mmdot/internal/core"
@@ -92,29 +90,33 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 			targetFile = file + ".age"
 		}
 
-		if _, err := os.Stat(sourceFile); os.IsNotExist(err) {
-			log.Debug().Str("file", sourceFile).Msg("Source file doesn't exist, skipping")
-			continue
+		if _, err := os.Stat(sourceFile); err != nil {
+			if os.IsNotExist(err) {
+				log.Debug().Str("file", sourceFile).Msg("Source file doesn't exist, skipping")
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", sourceFile, err)
 		}
 
 		if _, err := os.Stat(targetFile); err == nil {
 			log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, skipping")
 			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat %s: %w", targetFile, err)
 		}
 
 		vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
 	}
 
-	// Collect age.files that need encryption (dest exists, src doesn't)
+	// Collect age.files that need encryption (dest plaintext exists)
 	ageFilesToEncrypt := []core.AgeFile{}
 	for _, af := range cfg.Age.Files {
-		if _, err := os.Stat(af.Dest); os.IsNotExist(err) {
-			log.Debug().Str("dest", af.Dest).Msg("Plaintext dest doesn't exist, skipping")
-			continue
-		}
-		if _, err := os.Stat(af.Src); err == nil {
-			log.Debug().Str("src", af.Src).Msg("Encrypted src already exists, skipping")
-			continue
+		if _, err := os.Stat(af.Dest); err != nil {
+			if os.IsNotExist(err) {
+				log.Debug().Str("dest", af.Dest).Msg("Plaintext dest doesn't exist, skipping")
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", af.Dest, err)
 		}
 		ageFilesToEncrypt = append(ageFilesToEncrypt, af)
 	}
@@ -165,7 +167,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		log.Info().Str("file", targetFile).Msg("Vault file encrypted successfully")
 	}
 
-	// Encrypt age.files (dest -> src, delete dest)
+	// Encrypt age.files (dest -> src; EncryptFile removes the plaintext)
 	for _, af := range ageFilesToEncrypt {
 		if err := os.MkdirAll(filepath.Dir(af.Src), 0o755); err != nil {
 			return fmt.Errorf("failed to create parent dir for %s: %w", af.Src, err)
@@ -209,14 +211,19 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 			targetFile = file
 		}
 
-		if _, err := os.Stat(sourceFile); os.IsNotExist(err) {
-			log.Debug().Str("file", sourceFile).Msg("Encrypted file doesn't exist, skipping")
-			continue
+		if _, err := os.Stat(sourceFile); err != nil {
+			if os.IsNotExist(err) {
+				log.Debug().Str("file", sourceFile).Msg("Encrypted file doesn't exist, skipping")
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", sourceFile, err)
 		}
 
 		if _, err := os.Stat(targetFile); err == nil {
 			log.Debug().Str("file", targetFile).Msg("Decrypted file already exists, skipping")
 			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat %s: %w", targetFile, err)
 		}
 
 		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Decrypting vault file")
@@ -234,14 +241,19 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 
 	// Decrypt age.files (src -> dest, preserve .age file)
 	for _, af := range cfg.Age.Files {
-		if _, err := os.Stat(af.Src); os.IsNotExist(err) {
-			log.Debug().Str("src", af.Src).Msg("Encrypted age file doesn't exist, skipping")
-			continue
+		if _, err := os.Stat(af.Src); err != nil {
+			if os.IsNotExist(err) {
+				log.Debug().Str("src", af.Src).Msg("Encrypted age file doesn't exist, skipping")
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", af.Src, err)
 		}
 
 		if _, err := os.Stat(af.Dest); err == nil {
 			log.Debug().Str("dest", af.Dest).Msg("Decrypted age file already exists, skipping")
 			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat %s: %w", af.Dest, err)
 		}
 
 		if err := os.MkdirAll(filepath.Dir(af.Dest), 0o755); err != nil {
@@ -254,7 +266,7 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		if af.Permissions != "" {
-			perm, err := parsePermissions(af.Permissions)
+			perm, err := core.ParseOctalPermissions(af.Permissions)
 			if err != nil {
 				return fmt.Errorf("invalid permissions %q for %s: %w", af.Permissions, af.Dest, err)
 			}
@@ -263,8 +275,11 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 			}
 		}
 
-		if err := ensureGitignored(af.Dest); err != nil {
-			log.Warn().Str("dest", af.Dest).Err(err).Msg("Failed to ensure dest is gitignored")
+		relDest, err := filepath.Rel(".", af.Dest)
+		if err != nil || strings.HasPrefix(relDest, "..") {
+			log.Debug().Str("dest", af.Dest).Msg("Dest outside config dir, skipping gitignore")
+		} else if err := ensureGitignored(relDest); err != nil {
+			return fmt.Errorf("failed to gitignore %s: %w", af.Dest, err)
 		}
 
 		decryptedCount++
@@ -275,44 +290,34 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func parsePermissions(perm string) (os.FileMode, error) {
-	v, err := strconv.ParseUint(perm, 8, 32)
-	if err != nil {
-		return 0, fmt.Errorf("parse octal: %w", err)
-	}
-	return os.FileMode(v), nil
-}
-
 func ensureGitignored(path string) error {
 	gitignorePath := ".gitignore"
 
-	// Read existing gitignore
-	lines := []string{}
-	if f, err := os.Open(gitignorePath); err == nil {
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if line == path {
-				_ = f.Close()
-				return nil // already gitignored
-			}
-			lines = append(lines, line)
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if line == path {
+			return nil
 		}
-		_ = f.Close()
 	}
 
-	// Append the path
-	f, err := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-	if err != nil {
-		return fmt.Errorf("open .gitignore: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// Add newline before entry if file doesn't end with one
+	// Need a leading newline if file exists and doesn't end with one
 	prefix := ""
-	if len(lines) > 0 && lines[len(lines)-1] != "" {
+	if len(data) > 0 && data[len(data)-1] != '\n' {
 		prefix = "\n"
 	}
-	_, err = fmt.Fprintf(f, "%s%s\n", prefix, path)
-	return err
+
+	f, err := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore for writing: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(f, "%s%s\n", prefix, path); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }

--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -1,9 +1,12 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hay-kot/mmdot/internal/core"
@@ -76,63 +79,68 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	files := cfg.EncryptedFiles()
-	if len(files) == 0 {
-		log.Info().Msg("No files configured for encryption")
-		return nil
-	}
-
-	// Collect files that need encryption
-	filesToEncrypt := []string{}
-	for _, file := range files {
+	// Collect vault files that need encryption
+	vaultFilesToEncrypt := []string{}
+	for _, file := range cfg.EncryptedFiles() {
 		var sourceFile, targetFile string
 
-		// Determine source and target based on whether the configured file has .age extension
 		if strings.HasSuffix(file, ".age") {
-			// Config specifies encrypted file path
 			sourceFile = strings.TrimSuffix(file, ".age")
 			targetFile = file
 		} else {
-			// Config specifies plain file path
 			sourceFile = file
 			targetFile = file + ".age"
 		}
 
-		// Check if source file exists
 		if _, err := os.Stat(sourceFile); os.IsNotExist(err) {
 			log.Debug().Str("file", sourceFile).Msg("Source file doesn't exist, skipping")
 			continue
 		}
 
-		// Check if target file already exists
 		if _, err := os.Stat(targetFile); err == nil {
 			log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, skipping")
 			continue
 		}
 
-		filesToEncrypt = append(filesToEncrypt, sourceFile)
+		vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
 	}
 
-	// Dry-run mode: just check and report
-	if ec.dryRun {
-		if len(filesToEncrypt) > 0 {
-			log.Error().Msg("Found unencrypted vault files:")
-			for _, file := range filesToEncrypt {
-				log.Error().Str("file", file).Msg("  - needs encryption")
-			}
-			return fmt.Errorf("found %d unencrypted vault file(s)", len(filesToEncrypt))
+	// Collect age.files that need encryption (dest exists, src doesn't)
+	ageFilesToEncrypt := []core.AgeFile{}
+	for _, af := range cfg.Age.Files {
+		if _, err := os.Stat(af.Dest); os.IsNotExist(err) {
+			log.Debug().Str("dest", af.Dest).Msg("Plaintext dest doesn't exist, skipping")
+			continue
 		}
-		log.Info().Msg("All vault files are encrypted")
+		if _, err := os.Stat(af.Src); err == nil {
+			log.Debug().Str("src", af.Src).Msg("Encrypted src already exists, skipping")
+			continue
+		}
+		ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+	}
+
+	totalToEncrypt := len(vaultFilesToEncrypt) + len(ageFilesToEncrypt)
+
+	if ec.dryRun {
+		if totalToEncrypt > 0 {
+			log.Error().Msg("Found unencrypted files:")
+			for _, file := range vaultFilesToEncrypt {
+				log.Error().Str("file", file).Msg("  - vault file needs encryption")
+			}
+			for _, af := range ageFilesToEncrypt {
+				log.Error().Str("dest", af.Dest).Str("src", af.Src).Msg("  - age file needs encryption")
+			}
+			return fmt.Errorf("found %d unencrypted file(s)", totalToEncrypt)
+		}
+		log.Info().Msg("All files are encrypted")
 		return nil
 	}
 
-	// Normal mode: encrypt files
-	if len(filesToEncrypt) == 0 {
-		log.Info().Msg("All vault files are already encrypted")
+	if totalToEncrypt == 0 {
+		log.Info().Msg("All files are already encrypted")
 		return nil
 	}
 
-	// Load the public key
 	if len(cfg.Age.Recipients) == 0 {
 		return fmt.Errorf("no age recipients configured in mmdot.yaml")
 	}
@@ -142,25 +150,35 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to load public key: %w", err)
 	}
 
-	log.Info().Int("count", len(filesToEncrypt)).Msg("Encrypting files")
-
-	for _, sourceFile := range filesToEncrypt {
+	// Encrypt vault files
+	for _, sourceFile := range vaultFilesToEncrypt {
 		targetFile := sourceFile + ".age"
 		if strings.HasSuffix(sourceFile, ".age") {
 			targetFile = sourceFile
 			sourceFile = strings.TrimSuffix(sourceFile, ".age")
 		}
 
-		// Encrypt the file
-		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Encrypting file")
+		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Encrypting vault file")
 		if err := fcrypt.EncryptFile(sourceFile, targetFile, recipient); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", sourceFile, err)
 		}
-
-		log.Info().Str("file", targetFile).Msg("File encrypted successfully")
+		log.Info().Str("file", targetFile).Msg("Vault file encrypted successfully")
 	}
 
-	log.Info().Int("count", len(filesToEncrypt)).Msg("Encryption complete")
+	// Encrypt age.files (dest -> src, delete dest)
+	for _, af := range ageFilesToEncrypt {
+		if err := os.MkdirAll(filepath.Dir(af.Src), 0o755); err != nil {
+			return fmt.Errorf("failed to create parent dir for %s: %w", af.Src, err)
+		}
+
+		log.Info().Str("source", af.Dest).Str("target", af.Src).Msg("Encrypting age file")
+		if err := fcrypt.EncryptFile(af.Dest, af.Src, recipient); err != nil {
+			return fmt.Errorf("failed to encrypt %s: %w", af.Dest, err)
+		}
+		log.Info().Str("file", af.Src).Msg("Age file encrypted successfully")
+	}
+
+	log.Info().Int("count", totalToEncrypt).Msg("Encryption complete")
 	return nil
 }
 
@@ -176,55 +194,125 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	files := cfg.EncryptedFiles()
-	if len(files) == 0 {
-		log.Info().Msg("No files configured for decryption")
-		return nil
-	}
-
-	log.Info().Int("count", len(files)).Msg("Found files to decrypt")
 
 	decryptedCount := 0
+
+	// Decrypt vault files
 	for _, file := range files {
 		var sourceFile, targetFile string
 
-		// Determine source and target based on whether the configured file has .age extension
 		if strings.HasSuffix(file, ".age") {
-			// Config specifies encrypted file path
 			sourceFile = file
 			targetFile = strings.TrimSuffix(file, ".age")
 		} else {
-			// Config specifies plain file path - look for .age version
 			sourceFile = file + ".age"
 			targetFile = file
 		}
 
-		// Check if source file exists
 		if _, err := os.Stat(sourceFile); os.IsNotExist(err) {
 			log.Debug().Str("file", sourceFile).Msg("Encrypted file doesn't exist, skipping")
 			continue
 		}
 
-		// Check if target file already exists
 		if _, err := os.Stat(targetFile); err == nil {
 			log.Debug().Str("file", targetFile).Msg("Decrypted file already exists, skipping")
 			continue
 		}
 
-		// Decrypt the file
-		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Decrypting file")
+		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Decrypting vault file")
 		if err := fcrypt.DecryptFile(sourceFile, targetFile, identity); err != nil {
 			return fmt.Errorf("failed to decrypt %s: %w", sourceFile, err)
 		}
 
-		// Remove the encrypted file after successful decryption
 		if err := os.Remove(sourceFile); err != nil {
 			log.Warn().Str("file", sourceFile).Err(err).Msg("Failed to remove encrypted file after decryption")
 		}
 
 		decryptedCount++
-		log.Info().Str("file", targetFile).Msg("File decrypted successfully")
+		log.Info().Str("file", targetFile).Msg("Vault file decrypted successfully")
+	}
+
+	// Decrypt age.files (src -> dest, preserve .age file)
+	for _, af := range cfg.Age.Files {
+		if _, err := os.Stat(af.Src); os.IsNotExist(err) {
+			log.Debug().Str("src", af.Src).Msg("Encrypted age file doesn't exist, skipping")
+			continue
+		}
+
+		if _, err := os.Stat(af.Dest); err == nil {
+			log.Debug().Str("dest", af.Dest).Msg("Decrypted age file already exists, skipping")
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(af.Dest), 0o755); err != nil {
+			return fmt.Errorf("failed to create parent dir for %s: %w", af.Dest, err)
+		}
+
+		log.Info().Str("source", af.Src).Str("target", af.Dest).Msg("Decrypting age file")
+		if err := fcrypt.DecryptFile(af.Src, af.Dest, identity); err != nil {
+			return fmt.Errorf("failed to decrypt %s: %w", af.Src, err)
+		}
+
+		if af.Permissions != "" {
+			perm, err := parsePermissions(af.Permissions)
+			if err != nil {
+				return fmt.Errorf("invalid permissions %q for %s: %w", af.Permissions, af.Dest, err)
+			}
+			if err := os.Chmod(af.Dest, perm); err != nil {
+				return fmt.Errorf("failed to set permissions on %s: %w", af.Dest, err)
+			}
+		}
+
+		if err := ensureGitignored(af.Dest); err != nil {
+			log.Warn().Str("dest", af.Dest).Err(err).Msg("Failed to ensure dest is gitignored")
+		}
+
+		decryptedCount++
+		log.Info().Str("file", af.Dest).Msg("Age file decrypted successfully")
 	}
 
 	log.Info().Int("count", decryptedCount).Msg("Decryption complete")
 	return nil
+}
+
+func parsePermissions(perm string) (os.FileMode, error) {
+	v, err := strconv.ParseUint(perm, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse octal: %w", err)
+	}
+	return os.FileMode(v), nil
+}
+
+func ensureGitignored(path string) error {
+	gitignorePath := ".gitignore"
+
+	// Read existing gitignore
+	lines := []string{}
+	if f, err := os.Open(gitignorePath); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == path {
+				_ = f.Close()
+				return nil // already gitignored
+			}
+			lines = append(lines, line)
+		}
+		_ = f.Close()
+	}
+
+	// Append the path
+	f, err := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Add newline before entry if file doesn't end with one
+	prefix := ""
+	if len(lines) > 0 && lines[len(lines)-1] != "" {
+		prefix = "\n"
+	}
+	_, err = fmt.Fprintf(f, "%s%s\n", prefix, path)
+	return err
 }

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_parsePermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{name: "0644", input: "0644", want: 0o644},
+		{name: "0600", input: "0600", want: 0o600},
+		{name: "0755", input: "0755", want: 0o755},
+		{name: "invalid", input: "not-octal", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePermissions(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePermissions(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parsePermissions(%q) = %o, want %o", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Logf("warning: failed to restore working directory: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir to %s: %v", dir, err)
+	}
+}
+
+func Test_ensureGitignored(t *testing.T) {
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	path := "output/secret.md"
+
+	// First call should create .gitignore and add the path
+	if err := ensureGitignored(path); err != nil {
+		t.Fatalf("first ensureGitignored() error: %v", err)
+	}
+
+	data, err := os.ReadFile(".gitignore")
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+	if string(data) != path+"\n" {
+		t.Errorf(".gitignore content = %q, want %q", string(data), path+"\n")
+	}
+
+	// Second call should be a no-op (path already present)
+	if err := ensureGitignored(path); err != nil {
+		t.Fatalf("second ensureGitignored() error: %v", err)
+	}
+
+	data, _ = os.ReadFile(".gitignore")
+	if string(data) != path+"\n" {
+		t.Errorf("after second call, .gitignore content = %q, want %q", string(data), path+"\n")
+	}
+}
+
+func Test_ensureGitignored_existingContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	// Create existing .gitignore without trailing newline
+	if err := os.WriteFile(".gitignore", []byte("*.log"), 0o644); err != nil {
+		t.Fatalf("failed to write .gitignore: %v", err)
+	}
+
+	path := "output/secret.md"
+	if err := ensureGitignored(path); err != nil {
+		t.Fatalf("ensureGitignored() error: %v", err)
+	}
+
+	data, _ := os.ReadFile(".gitignore")
+	want := "*.log\n" + path + "\n"
+	if string(data) != want {
+		t.Errorf(".gitignore content = %q, want %q", string(data), want)
+	}
+}

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -5,33 +5,6 @@ import (
 	"testing"
 )
 
-func Test_parsePermissions(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    os.FileMode
-		wantErr bool
-	}{
-		{name: "0644", input: "0644", want: 0o644},
-		{name: "0600", input: "0600", want: 0o600},
-		{name: "0755", input: "0755", want: 0o755},
-		{name: "invalid", input: "not-octal", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePermissions(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parsePermissions(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr && got != tt.want {
-				t.Errorf("parsePermissions(%q) = %o, want %o", tt.input, got, tt.want)
-			}
-		})
-	}
-}
-
 func chdir(t *testing.T, dir string) {
 	t.Helper()
 	origDir, err := os.Getwd()
@@ -78,12 +51,33 @@ func Test_ensureGitignored(t *testing.T) {
 	}
 }
 
-func Test_ensureGitignored_existingContent(t *testing.T) {
+func Test_ensureGitignored_existingContentNoTrailingNewline(t *testing.T) {
 	tmpDir := t.TempDir()
 	chdir(t, tmpDir)
 
 	// Create existing .gitignore without trailing newline
 	if err := os.WriteFile(".gitignore", []byte("*.log"), 0o644); err != nil {
+		t.Fatalf("failed to write .gitignore: %v", err)
+	}
+
+	path := "output/secret.md"
+	if err := ensureGitignored(path); err != nil {
+		t.Fatalf("ensureGitignored() error: %v", err)
+	}
+
+	data, _ := os.ReadFile(".gitignore")
+	want := "*.log\n" + path + "\n"
+	if string(data) != want {
+		t.Errorf(".gitignore content = %q, want %q", string(data), want)
+	}
+}
+
+func Test_ensureGitignored_existingContentWithTrailingNewline(t *testing.T) {
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	// Create existing .gitignore with trailing newline
+	if err := os.WriteFile(".gitignore", []byte("*.log\n"), 0o644); err != nil {
 		t.Fatalf("failed to write .gitignore: %v", err)
 	}
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -113,6 +113,21 @@ func (c *ConfigFile) resolvePaths(pr PathResolver) error {
 		}
 	}
 
+	// Resolve age file paths
+	for i := range c.Age.Files {
+		resolved, err := pr.Resolve(c.Age.Files[i].Src)
+		if err != nil {
+			return fmt.Errorf("failed to resolve age file src path: %w", err)
+		}
+		c.Age.Files[i].Src = resolved
+
+		resolved, err = pr.Resolve(c.Age.Files[i].Dest)
+		if err != nil {
+			return fmt.Errorf("failed to resolve age file dest path: %w", err)
+		}
+		c.Age.Files[i].Dest = resolved
+	}
+
 	// Resolve exec script paths
 	for i := range c.Exec.Scripts {
 		resolved, err := pr.Resolve(c.Exec.Scripts[i].Path)
@@ -138,9 +153,16 @@ func (c ConfigFile) EncryptedFiles() []string {
 	return files
 }
 
+type AgeFile struct {
+	Src         string `yaml:"src"`
+	Dest        string `yaml:"dest"`
+	Permissions string `yaml:"perm"`
+}
+
 type Age struct {
-	Recipients   []string `yaml:"recipients"`
-	IdentityFile string   `yaml:"identity_file"`
+	Recipients   []string  `yaml:"recipients"`
+	IdentityFile string    `yaml:"identity_file"`
+	Files        []AgeFile `yaml:"files"`
 }
 
 func (a Age) ReadIdentity() (age.Identity, error) {

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"filippo.io/age"
@@ -113,8 +114,12 @@ func (c *ConfigFile) resolvePaths(pr PathResolver) error {
 		}
 	}
 
-	// Resolve age file paths
+	// Validate and resolve age file paths
 	for i := range c.Age.Files {
+		if err := c.Age.Files[i].Validate(); err != nil {
+			return err
+		}
+
 		resolved, err := pr.Resolve(c.Age.Files[i].Src)
 		if err != nil {
 			return fmt.Errorf("failed to resolve age file src path: %w", err)
@@ -157,6 +162,33 @@ type AgeFile struct {
 	Src         string `yaml:"src"`
 	Dest        string `yaml:"dest"`
 	Permissions string `yaml:"perm"`
+}
+
+func (af AgeFile) Validate() error {
+	if af.Src == "" {
+		return fmt.Errorf("age file: src is required")
+	}
+	if af.Dest == "" {
+		return fmt.Errorf("age file: dest is required")
+	}
+	if af.Src == af.Dest {
+		return fmt.Errorf("age file: src and dest must differ")
+	}
+	if af.Permissions != "" {
+		if _, err := ParseOctalPermissions(af.Permissions); err != nil {
+			return fmt.Errorf("age file %s: %w", af.Src, err)
+		}
+	}
+	return nil
+}
+
+// ParseOctalPermissions parses an octal permission string (e.g. "0600") into an os.FileMode.
+func ParseOctalPermissions(s string) (os.FileMode, error) {
+	v, err := strconv.ParseUint(s, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid permissions %q: %w", s, err)
+	}
+	return os.FileMode(v), nil
 }
 
 type Age struct {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -72,3 +72,92 @@ func TestResolvePaths_AgeFiles(t *testing.T) {
 		t.Errorf("files[1].Dest = %q, want %q", cfg.Age.Files[1].Dest, wantDest)
 	}
 }
+
+func TestParseOctalPermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{name: "0644", input: "0644", want: 0o644},
+		{name: "0600", input: "0600", want: 0o600},
+		{name: "0755", input: "0755", want: 0o755},
+		{name: "no leading zero", input: "644", want: 0o644},
+		{name: "invalid", input: "not-octal", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseOctalPermissions(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseOctalPermissions(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseOctalPermissions(%q) = %o, want %o", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgeFile_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		af      AgeFile
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			af:   AgeFile{Src: "a.age", Dest: "a.txt"},
+		},
+		{
+			name: "valid with permissions",
+			af:   AgeFile{Src: "a.age", Dest: "a.txt", Permissions: "0600"},
+		},
+		{
+			name:    "empty src",
+			af:      AgeFile{Src: "", Dest: "a.txt"},
+			wantErr: true,
+		},
+		{
+			name:    "empty dest",
+			af:      AgeFile{Src: "a.age", Dest: ""},
+			wantErr: true,
+		},
+		{
+			name:    "src equals dest",
+			af:      AgeFile{Src: "same", Dest: "same"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid permissions",
+			af:      AgeFile{Src: "a.age", Dest: "a.txt", Permissions: "garbage"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.af.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolvePaths_AgeFiles_ValidationFailure(t *testing.T) {
+	cfg := &ConfigFile{
+		Age: Age{
+			Files: []AgeFile{
+				{Src: "", Dest: "output/file.md"},
+			},
+		},
+	}
+
+	pr := PathResolver{configDir: "/config/dir"}
+	if err := cfg.resolvePaths(pr); err == nil {
+		t.Fatal("resolvePaths() expected error for invalid AgeFile, got nil")
+	}
+}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+func TestAgeFile_YAMLParsing(t *testing.T) {
+	input := `
+recipients:
+  - age1abc123
+identity_file: ~/.age/key
+files:
+  - src: secrets/file.md.age
+    dest: output/file.md
+  - src: secrets/config.yml.age
+    dest: .config/work.yml
+    perm: "0600"
+`
+	var age Age
+	if err := yaml.Unmarshal([]byte(input), &age); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(age.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(age.Files))
+	}
+
+	if age.Files[0].Src != "secrets/file.md.age" {
+		t.Errorf("files[0].Src = %q, want %q", age.Files[0].Src, "secrets/file.md.age")
+	}
+	if age.Files[0].Dest != "output/file.md" {
+		t.Errorf("files[0].Dest = %q, want %q", age.Files[0].Dest, "output/file.md")
+	}
+	if age.Files[0].Permissions != "" {
+		t.Errorf("files[0].Permissions = %q, want empty", age.Files[0].Permissions)
+	}
+
+	if age.Files[1].Permissions != "0600" {
+		t.Errorf("files[1].Permissions = %q, want %q", age.Files[1].Permissions, "0600")
+	}
+}
+
+func TestResolvePaths_AgeFiles(t *testing.T) {
+	cfg := &ConfigFile{
+		Age: Age{
+			Files: []AgeFile{
+				{Src: "secrets/file.age", Dest: "output/file.md"},
+				{Src: "secrets/other.age", Dest: "~/docs/other.md"},
+			},
+		},
+	}
+
+	pr := PathResolver{configDir: "/config/dir"}
+	if err := cfg.resolvePaths(pr); err != nil {
+		t.Fatalf("resolvePaths() error: %v", err)
+	}
+
+	if cfg.Age.Files[0].Src != "/config/dir/secrets/file.age" {
+		t.Errorf("files[0].Src = %q, want %q", cfg.Age.Files[0].Src, "/config/dir/secrets/file.age")
+	}
+	if cfg.Age.Files[0].Dest != "/config/dir/output/file.md" {
+		t.Errorf("files[0].Dest = %q, want %q", cfg.Age.Files[0].Dest, "/config/dir/output/file.md")
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	wantDest := filepath.Join(homeDir, "docs/other.md")
+	if cfg.Age.Files[1].Dest != wantDest {
+		t.Errorf("files[1].Dest = %q, want %q", cfg.Age.Files[1].Dest, wantDest)
+	}
+}

--- a/internal/generator/engine.go
+++ b/internal/generator/engine.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"strconv"
 	"text/template"
 
 	"filippo.io/age"
@@ -71,11 +70,11 @@ func (e *Engine) RenderTemplate(ctx context.Context, tmpl core.Template) error {
 	// Parse permissions
 	perm := os.FileMode(0o644)
 	if tmpl.Permissions != "" {
-		p, err := strconv.ParseUint(tmpl.Permissions, 8, 32)
+		p, err := core.ParseOctalPermissions(tmpl.Permissions)
 		if err != nil {
 			return fmt.Errorf("invalid permissions %s: %w", tmpl.Permissions, err)
 		}
-		perm = os.FileMode(p)
+		perm = p
 	}
 
 	// Write output file


### PR DESCRIPTION
## Summary

Adds an `age.files` config section that maps encrypted `.age` source files to decrypted destination paths. This enables committing encrypted private files to a public repo and decrypting them to arbitrary locations on each machine.

Encrypt reads plaintext from dest → src (deleting plaintext). Decrypt reads src → dest (preserving `.age` file), creates parent dirs, sets optional permissions, and auto-adds dest to `.gitignore`.