### PR TITLE
feat: expose brew groups as template variables

### DIFF
--- a/internal/commands/cmd_brew.go
+++ b/internal/commands/cmd_brew.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/hay-kot/mmdot/internal/core"
 	"github.com/hay-kot/mmdot/pkgs/printer"
-	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 )
 
@@ -45,15 +43,6 @@ Example: mmdot brew diff personal`,
 					},
 				},
 				Action: bc.diff,
-			},
-			{
-				Name:  "compile",
-				Usage: "Compile brew configurations to their output files",
-				Description: `Generates Brewfile outputs for all brew configurations that have an 'outfile' specified.
-This is useful for creating Brewfiles that can be used with 'brew bundle'.
-
-The compiled files will be written to the paths specified in each brew configuration's 'outfile' field.`,
-				Action: bc.compile,
 			},
 		},
 	}
@@ -138,32 +127,3 @@ func (bc *BrewCmd) diff(ctx context.Context, c *cli.Command) error {
 	return nil
 }
 
-func (bc *BrewCmd) compile(ctx context.Context, c *cli.Command) error {
-	cfg, err := core.SetupEnv(bc.flags.ConfigFilePath)
-	if err != nil {
-		return err
-	}
-
-	for v := range cfg.Brews {
-		cfg := cfg.Brews.Get(v)
-
-		if cfg.Outfile == "" {
-			continue
-		}
-
-		// Create directory
-		err := os.MkdirAll(filepath.Dir(cfg.Outfile), 0o755)
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(cfg.Outfile, []byte(cfg.String()), 0o644)
-		if err != nil {
-			return err
-		}
-
-		log.Info().Str("file", cfg.Outfile).Msg("outfile written")
-	}
-
-	return nil
-}

--- a/internal/core/config_brew.go
+++ b/internal/core/config_brew.go
@@ -1,95 +1,11 @@
 package core
 
-import (
-	"fmt"
-	"strings"
-)
-
 type Brews struct {
-	Remove   bool     `yaml:"remove"`
-	Outfile  string   `yaml:"outfile"`
 	Includes []string `yaml:"includes"`
 	Brews    []string `yaml:"brews"`
 	Taps     []string `yaml:"taps"`
 	Casks    []string `yaml:"casks"`
 	MAS      []string `yaml:"mas"`
-}
-
-// String returns a shell script to install the taps and brews
-func (c *Brews) String() string {
-	var script strings.Builder
-
-	script.WriteString(`#!/bin/bash
-
-# Exit immediately if a command exits with a non-zero status
-set -e
-# Exit if any command in a pipeline fails (not just the last one)
-set -o pipefail
-# Treat unset variables as an error when substituting
-set -u
-`)
-
-	actionTap := "tap"
-	actionInstall := "install"
-	if c.Remove {
-		actionTap = "untap"
-		actionInstall = "uninstall"
-	}
-
-	// Add taps - all in one command if there are any
-	if len(c.Taps) > 0 {
-		script.WriteString("# Adding Homebrew Taps\n")
-		for _, tap := range c.Taps {
-			script.WriteString(fmt.Sprintf("brew %s %s\n", actionTap, tap))
-		}
-		script.WriteString("\n")
-	}
-
-	// Install brews - all in one command if there are any
-	if len(c.Brews) > 0 {
-		script.WriteString("# Installing Homebrew Packages\n")
-		if len(c.Brews) == 1 {
-			script.WriteString(fmt.Sprintf("brew %s %s\n", actionInstall, c.Brews[0]))
-		} else {
-			script.WriteString(fmt.Sprintf("brew %s \\\n", actionInstall))
-			for i, brew := range c.Brews {
-				if i == len(c.Brews)-1 {
-					script.WriteString(fmt.Sprintf("  %s\n", brew))
-				} else {
-					script.WriteString(fmt.Sprintf("  %s \\\n", brew))
-				}
-			}
-		}
-		script.WriteString("\n")
-	}
-
-	// Install casks - all in one command if there are any
-	if len(c.Casks) > 0 {
-		script.WriteString("# Installing Homebrew Casks\n")
-		if len(c.Casks) == 1 {
-			script.WriteString(fmt.Sprintf("brew %s --cask %s\n", actionInstall, c.Casks[0]))
-		} else {
-			script.WriteString(fmt.Sprintf("brew %s --cask \\\n", actionInstall))
-			for i, cask := range c.Casks {
-				if i == len(c.Casks)-1 {
-					script.WriteString(fmt.Sprintf("  %s\n", cask))
-				} else {
-					script.WriteString(fmt.Sprintf("  %s \\\n", cask))
-				}
-			}
-		}
-		script.WriteString("\n")
-	}
-
-	// Install Mac App Store apps - unfortunately mas doesn't support batch installs
-	if len(c.MAS) > 0 {
-		script.WriteString("# Installing Mac App Store Apps\n")
-		for _, app := range c.MAS {
-			script.WriteString(fmt.Sprintf("mas install %s\n", app))
-		}
-	}
-
-	return script.String()
 }
 
 type ConfigMap map[string]*Brews
@@ -109,12 +25,10 @@ func (cm ConfigMap) Get(key string) *Brews {
 
 	// Merge included configurations
 	mergedConfig := &Brews{
-		Remove:  baseConfig.Remove,
-		Outfile: baseConfig.Outfile,
-		Brews:   make([]string, 0),
-		Taps:    make([]string, 0),
-		Casks:   make([]string, 0),
-		MAS:     make([]string, 0),
+		Brews: make([]string, 0),
+		Taps:  make([]string, 0),
+		Casks: make([]string, 0),
+		MAS:   make([]string, 0),
 	}
 
 	// Recursively merge includes

--- a/internal/generator/engine.go
+++ b/internal/generator/engine.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"text/template"
 
 	"filippo.io/age"
@@ -40,7 +41,12 @@ func (e *Engine) RenderTemplate(ctx context.Context, tmpl core.Template) error {
 	}
 
 	// Parse and execute template
-	t := template.New(tmpl.Name)
+	funcMap := template.FuncMap{
+		"last": func(i int, slice any) bool {
+			return i == reflect.ValueOf(slice).Len()-1
+		},
+	}
+	t := template.New(tmpl.Name).Funcs(funcMap)
 	t, err := t.Parse(tmpl.Template)
 	if err != nil {
 		return NewTemplateError(tmpl.Name, err)
@@ -111,6 +117,21 @@ func (e *Engine) preloadVars() error {
 
 		// Merge into fileVars
 		maps.Copy(e.fileVars, vars)
+	}
+
+	// Inject brew groups as template variables
+	if len(e.cfg.Brews) > 0 {
+		brewVars := make(map[string]any, len(e.cfg.Brews))
+		for name := range e.cfg.Brews {
+			resolved := e.cfg.Brews.Get(name)
+			brewVars[name] = map[string]any{
+				"brews": resolved.Brews,
+				"casks": resolved.Casks,
+				"taps":  resolved.Taps,
+				"mas":   resolved.MAS,
+			}
+		}
+		e.globalVars["Brews"] = brewVars
 	}
 
 	return nil

--- a/mmdot.yml
+++ b/mmdot.yml
@@ -26,6 +26,35 @@ templates:
       {{- end }}
     output: .data/generated/.env.local
     perm: "0600"
+  - name: Grafana Brew Script
+    tags: [work, brew]
+    output: .data/generated/brew.grafana.sh
+    perm: "0755"
+    trim: false
+    template: |
+      #!/bin/bash
+      set -euo pipefail
+
+      # Taps
+      {{- range .Brews.grafana.taps }}
+      brew tap {{ . }}
+      {{- end }}
+
+      # Formulae
+      {{- if .Brews.grafana.brews }}
+      brew install \
+      {{- range $i, $v := .Brews.grafana.brews }}
+        {{ $v }}{{ if not (last $i $.Brews.grafana.brews) }} \{{ end }}
+      {{- end }}
+      {{- end }}
+
+      # Casks
+      {{- if .Brews.grafana.casks }}
+      brew install --cask \
+      {{- range $i, $v := .Brews.grafana.casks }}
+        {{ $v }}{{ if not (last $i $.Brews.grafana.casks) }} \{{ end }}
+      {{- end }}
+      {{- end }}
 
 exec:
   shell: /bin/bash
@@ -37,39 +66,19 @@ exec:
 
 brew:
   grafana:
-    outfile: .data/generated/brew.grafana.sh
-    includes:
-      - all
-    brews:
-      - terraform
-      - helm
-    taps:
-      - hashicorp/tap
-    casks:
-      - goland
-      - google-cloud-sdk
-    mas: []
+    includes: [all]
+    brews: [terraform, helm]
+    taps: [hashicorp/tap]
+    casks: [goland, google-cloud-sdk]
   personal:
-    outfile: .data/generated/brew.personal.sh
-    includes:
-      - all
-    taps:
-      - stripe/stripe-cli
-    brews:
-      - caddy
-      - hugo
-    casks:
-      - obsidian
-      - spotify
+    includes: [all]
+    taps: [stripe/stripe-cli]
+    brews: [caddy, hugo]
+    casks: [obsidian, spotify]
   all:
-    taps:
-      - go-task/tap
-    brews:
-      - git
-      - neovim
-    casks:
-      - wezterm
-      - visual-studio-code
+    taps: [go-task/tap]
+    brews: [git, neovim]
+    casks: [wezterm, visual-studio-code]
 
 age:
   identity_file: .data/age/key.txt


### PR DESCRIPTION
## Summary

- Injects resolved brew configs into the template engine as `.Brews.<name>` variables, making `.Brews.grafana.brews`, `.Brews.grafana.casks`, etc. available in all templates
- Removes `brew compile` command, `Brews.String()` method, and `Outfile`/`Remove` fields — brew script generation is now handled by the existing template system
- Registers a `last` template function for detecting final elements in range loops (needed for `\` line continuations)
- Adds example brew script template to `mmdot.yml` demonstrating the new pattern

## Test plan

- [x] `task test` — 51 tests pass
- [x] `task lint` — 0 issues
- [x] `go build ./...` — compiles clean
- [ ] Manual: `mmdot run +brew` generates expected brew script output
- [ ] Manual: `mmdot brew diff personal` still works against installed packages