### PR TITLE
feat: consolidate brew file generation into template system

### DIFF
--- a/internal/commands/cmd_brew.go
+++ b/internal/commands/cmd_brew.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/hay-kot/mmdot/internal/core"
 	"github.com/hay-kot/mmdot/pkgs/printer"
-	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 )
 
@@ -45,15 +43,6 @@ Example: mmdot brew diff personal`,
 					},
 				},
 				Action: bc.diff,
-			},
-			{
-				Name:  "compile",
-				Usage: "Compile brew configurations to their output files",
-				Description: `Generates Brewfile outputs for all brew configurations that have an 'outfile' specified.
-This is useful for creating Brewfiles that can be used with 'brew bundle'.
-
-The compiled files will be written to the paths specified in each brew configuration's 'outfile' field.`,
-				Action: bc.compile,
 			},
 		},
 	}
@@ -138,32 +127,3 @@ func (bc *BrewCmd) diff(ctx context.Context, c *cli.Command) error {
 	return nil
 }
 
-func (bc *BrewCmd) compile(ctx context.Context, c *cli.Command) error {
-	cfg, err := core.SetupEnv(bc.flags.ConfigFilePath)
-	if err != nil {
-		return err
-	}
-
-	for v := range cfg.Brews {
-		cfg := cfg.Brews.Get(v)
-
-		if cfg.Outfile == "" {
-			continue
-		}
-
-		// Create directory
-		err := os.MkdirAll(filepath.Dir(cfg.Outfile), 0o755)
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(cfg.Outfile, []byte(cfg.String()), 0o644)
-		if err != nil {
-			return err
-		}
-
-		log.Info().Str("file", cfg.Outfile).Msg("outfile written")
-	}
-
-	return nil
-}

--- a/internal/commands/cmd_brew.go
+++ b/internal/commands/cmd_brew.go
@@ -63,7 +63,7 @@ func (bc *BrewCmd) diff(ctx context.Context, c *cli.Command) error {
 	}
 	brewCfg := cfg.Brews.Get(arg)
 	if brewCfg == nil {
-		panic("brew config not found")
+		return fmt.Errorf("brew config %q not found", arg)
 	}
 	diff, err := brewCfg.Diff()
 	if err != nil {

--- a/internal/commands/cmd_llmtext.go
+++ b/internal/commands/cmd_llmtext.go
@@ -60,7 +60,6 @@ func (lc *LLMTextCmd) config(ctx context.Context, c *cli.Command) error {
 
 	fmt.Fprintf(&out, "# mmdot config (current: v%d)\n\n", core.ConfigVersion)
 
-	// Migration notes
 	if userVersion < core.ConfigVersion {
 		fmt.Fprintf(&out, "## Your config: v%d — migrations needed\n\n", userVersion)
 		writeMigrationNotes(&out, userVersion, core.ConfigVersion)
@@ -68,15 +67,10 @@ func (lc *LLMTextCmd) config(ctx context.Context, c *cli.Command) error {
 		fmt.Fprintf(&out, "## Your config: v%d — up to date\n\n", userVersion)
 	}
 
-	// Schema reference
 	out.WriteString(mustReadEmbed("llmtext/config_schema.txt"))
 	out.WriteString("\n")
-
-	// Template functions and partials
 	out.WriteString(mustReadEmbed("llmtext/template_docs.txt"))
 	out.WriteString("\n")
-
-	// Migration history
 	writeMigrationHistory(&out)
 
 	fmt.Print(out.String())

--- a/internal/commands/cmd_llmtext.go
+++ b/internal/commands/cmd_llmtext.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/hay-kot/mmdot/internal/core"
+	"github.com/hay-kot/mmdot/internal/migrations"
+	"github.com/urfave/cli/v3"
+)
+
+//go:embed llmtext/*.txt
+var llmtextFS embed.FS
+
+type LLMTextCmd struct {
+	flags *core.Flags
+}
+
+func NewLLMTextCmd(flags *core.Flags) *LLMTextCmd {
+	return &LLMTextCmd{flags: flags}
+}
+
+func (lc *LLMTextCmd) Register(app *cli.Command) *cli.Command {
+	cmd := &cli.Command{
+		Name:  "llmtext",
+		Usage: "Output LLM-consumable documentation",
+		Commands: []*cli.Command{
+			{
+				Name:  "config",
+				Usage: "Output config schema, template functions, and migration notes",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "version",
+						Usage: "override config version (default: read from config file)",
+					},
+				},
+				Action: lc.config,
+			},
+		},
+	}
+
+	app.Commands = append(app.Commands, cmd)
+	return app
+}
+
+func (lc *LLMTextCmd) config(ctx context.Context, c *cli.Command) error {
+	userVersion := int(c.Int("version"))
+
+	if userVersion == 0 {
+		cfg, err := core.SetupEnv(lc.flags.ConfigFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+		userVersion = cfg.Version
+	}
+
+	var out strings.Builder
+
+	fmt.Fprintf(&out, "# mmdot config (current: v%d)\n\n", core.ConfigVersion)
+
+	// Migration notes
+	if userVersion < core.ConfigVersion {
+		fmt.Fprintf(&out, "## Your config: v%d — migrations needed\n\n", userVersion)
+		writeMigrationNotes(&out, userVersion, core.ConfigVersion)
+	} else {
+		fmt.Fprintf(&out, "## Your config: v%d — up to date\n\n", userVersion)
+	}
+
+	// Schema reference
+	out.WriteString(mustReadEmbed("llmtext/config_schema.txt"))
+	out.WriteString("\n")
+
+	// Template functions and partials
+	out.WriteString(mustReadEmbed("llmtext/template_docs.txt"))
+	out.WriteString("\n")
+
+	// Migration history
+	writeMigrationHistory(&out)
+
+	fmt.Print(out.String())
+	return nil
+}
+
+func mustReadEmbed(path string) string {
+	data, err := llmtextFS.ReadFile(path)
+	if err != nil {
+		panic("failed to read embedded file " + path + ": " + err.Error())
+	}
+	return string(data)
+}
+
+func writeMigrationNotes(out *strings.Builder, from, to int) {
+	for _, note := range migrations.Notes {
+		if note.Version > from && note.Version <= to {
+			out.WriteString(note.Body)
+			out.WriteString("\n")
+		}
+	}
+}
+
+func writeMigrationHistory(out *strings.Builder) {
+	out.WriteString("## Migration History\n\n")
+	for _, note := range migrations.Notes {
+		fmt.Fprintf(out, "- v%d → v%d: %s\n", note.Version-1, note.Version, note.Summary)
+	}
+	out.WriteString("\n")
+}

--- a/internal/commands/cmd_llmtext_test.go
+++ b/internal/commands/cmd_llmtext_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hay-kot/mmdot/internal/core"
+)
+
+func TestWriteMigrationNotes_FromV1(t *testing.T) {
+	var out strings.Builder
+	writeMigrationNotes(&out, 1, core.ConfigVersion)
+
+	result := out.String()
+	if result == "" {
+		t.Fatal("expected migration notes, got empty string")
+	}
+
+	for _, want := range []string{
+		"v1 → v2",
+		"brew compile",
+		"brewfile",
+		"brewConfig",
+		"outfile",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("migration notes missing %q", want)
+		}
+	}
+}
+
+func TestWriteMigrationNotes_CurrentVersion(t *testing.T) {
+	var out strings.Builder
+	writeMigrationNotes(&out, core.ConfigVersion, core.ConfigVersion)
+
+	if out.String() != "" {
+		t.Errorf("expected no migration notes for current version, got: %s", out.String())
+	}
+}
+
+func TestEmbeddedConfigSchema(t *testing.T) {
+	content := mustReadEmbed("llmtext/config_schema.txt")
+
+	for _, want := range []string{
+		"version:",
+		"templates:",
+		"brews:",
+		"variables:",
+		"age:",
+		"Variable precedence",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("schema reference missing %q", want)
+		}
+	}
+}
+
+func TestEmbeddedTemplateDocs(t *testing.T) {
+	content := mustReadEmbed("llmtext/template_docs.txt")
+
+	for _, want := range []string{
+		"brewConfig",
+		"brewfile",
+		"Built-in Partials",
+		"Template Functions",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("template docs missing %q", want)
+		}
+	}
+}

--- a/internal/commands/llmtext/config_schema.txt
+++ b/internal/commands/llmtext/config_schema.txt
@@ -1,0 +1,67 @@
+## Config Schema
+
+```yaml
+# Config schema version
+version: <int>
+
+# Variable substitution macros
+macros:
+  <name>: <value>
+
+# Global and file-based template variables
+variables:
+  vars:
+    <key>: <value>
+  var_files:
+    - path/to/vars.yml
+    - path/to/secret.yml?vault=true  # decrypted with age
+
+# Age encryption configuration
+age:
+  recipients:
+    - <age-public-key>
+  identity_file: path/to/key.txt
+  files:
+    - src: path/to/file
+      dest: path/to/file.age
+      perm: "0600"  # optional
+
+# Template definitions
+templates:
+  - name: <template-name>
+    tags: [<tag>, ...]           # for filtering with selectors
+    template: <inline-template>  # Go template string or file path
+    output: path/to/output
+    perm: "0644"                 # optional, octal permissions
+    trim: true                   # optional, trim whitespace (default: true)
+    vars:                        # optional, template-specific variables
+      <key>: <value>
+
+# Homebrew package definitions (used by brew diff and brewfile partial)
+brews:
+  <name>:
+    remove: false            # optional, generate uninstall instead of install
+    includes: [<other-name>] # optional, merge other brew configs
+    taps: [<tap>, ...]
+    brews: [<package>, ...]
+    casks: [<cask>, ...]
+    mas: [<app-id>, ...]
+
+# Shell script execution
+exec:
+  shell: /bin/bash
+  scripts:
+    - path: path/to/script.sh
+      tags: [<tag>, ...]
+```
+
+### Variable precedence
+
+Variables are merged with later sources overriding earlier:
+1. `variables.vars` (global inline)
+2. `variables.var_files` (file-based, in order)
+3. `templates[].vars` (template-specific)
+
+### Paths
+
+All paths in config are relative to the config file directory.

--- a/internal/commands/llmtext/template_docs.txt
+++ b/internal/commands/llmtext/template_docs.txt
@@ -1,0 +1,43 @@
+## Template Functions
+
+### brewConfig
+
+Resolves a named brew configuration (with includes merged) and returns the Brews struct.
+
+```
+{{$b := brewConfig "personal"}}
+{{range $b.Taps}}brew tap {{.}}{{end}}
+{{range $b.Brews}}brew install {{.}}{{end}}
+{{range $b.Casks}}brew install --cask {{.}}{{end}}
+{{range $b.MAS}}mas install {{.}}{{end}}
+```
+
+The returned struct has fields: Taps, Brews, Casks, MAS (all []string), and Remove (bool).
+
+## Built-in Partials
+
+### brewfile
+
+Renders brew tap/install/uninstall commands for a named brew config. Handles the Remove flag automatically.
+
+```
+{{template "brewfile" "personal"}}
+```
+
+Generates output like:
+
+```bash
+# Homebrew Taps
+brew tap homebrew/cask
+
+# Homebrew Packages
+brew install git
+brew install vim
+
+# Homebrew Casks
+brew install --cask firefox
+```
+
+## Available Brew Configs
+
+Use `mmdot brew diff` to see available brew config names, or check the `brews:` section in your mmdot.yml.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -13,7 +13,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ConfigVersion is the current config schema version. Increment this when
+// making breaking changes to the config format and add a corresponding
+// migration note in the migrations package.
+const ConfigVersion = 2
+
 type ConfigFile struct {
+	Version   int               `yaml:"version"`
 	Macros    map[string]string `yaml:"macros"`
 	Exec      Exec              `yaml:"exec"`
 	Age       Age               `yaml:"age"`
@@ -63,6 +69,11 @@ func SetupEnv(cfgpath string) (ConfigFile, error) {
 	err = yaml.Unmarshal(data, &cfg)
 	if err != nil {
 		return cfg, err
+	}
+
+	// Default to version 1 for pre-existing configs without a version field
+	if cfg.Version == 0 {
+		cfg.Version = 1
 	}
 
 	// Create path resolver and resolve all paths in config

--- a/internal/core/config_brew.go
+++ b/internal/core/config_brew.go
@@ -9,67 +9,57 @@ type Brews struct {
 	MAS      []string `yaml:"mas"`
 }
 
+func (b *Brews) merge(other *Brews) {
+	b.Brews = append(b.Brews, other.Brews...)
+	b.Taps = append(b.Taps, other.Taps...)
+	b.Casks = append(b.Casks, other.Casks...)
+	b.MAS = append(b.MAS, other.MAS...)
+}
+
 type ConfigMap map[string]*Brews
 
 func (cm ConfigMap) Get(key string) *Brews {
-	// If the key doesn't exist, return nil
 	if _, exists := cm[key]; !exists {
 		return nil
 	}
 
-	// Start with the base configuration
 	baseConfig := cm[key]
 
-	// Create a set to track processed configs to prevent circular includes
+	// Track processed configs to prevent circular includes
 	processedConfigs := make(map[string]bool)
 	processedConfigs[key] = true
 
-	// Merge included configurations
 	mergedConfig := &Brews{
 		Remove: baseConfig.Remove,
 		Brews:  make([]string, 0),
-		Taps:    make([]string, 0),
-		Casks:   make([]string, 0),
-		MAS:     make([]string, 0),
+		Taps:   make([]string, 0),
+		Casks:  make([]string, 0),
+		MAS:    make([]string, 0),
 	}
 
-	// Recursively merge includes
 	for _, include := range baseConfig.Includes {
-		includedConfig := mergeIncludes(cm, include, processedConfigs)
-		if includedConfig != nil {
-			mergedConfig.Brews = append(mergedConfig.Brews, includedConfig.Brews...)
-			mergedConfig.Taps = append(mergedConfig.Taps, includedConfig.Taps...)
-			mergedConfig.Casks = append(mergedConfig.Casks, includedConfig.Casks...)
-			mergedConfig.MAS = append(mergedConfig.MAS, includedConfig.MAS...)
+		if included := mergeIncludes(cm, include, processedConfigs); included != nil {
+			mergedConfig.merge(included)
 		}
 	}
 
-	// Add base config items
-	mergedConfig.Brews = append(mergedConfig.Brews, baseConfig.Brews...)
-	mergedConfig.Taps = append(mergedConfig.Taps, baseConfig.Taps...)
-	mergedConfig.Casks = append(mergedConfig.Casks, baseConfig.Casks...)
-	mergedConfig.MAS = append(mergedConfig.MAS, baseConfig.MAS...)
+	mergedConfig.merge(baseConfig)
 
 	return mergedConfig
 }
 
-// Helper method to recursively merge included configurations
 func mergeIncludes(cm map[string]*Brews, key string, processed map[string]bool) *Brews {
-	// Check for circular dependency
 	if processed[key] {
 		return nil
 	}
 
-	// Get the configuration for the key
 	config, exists := cm[key]
 	if !exists {
 		return nil
 	}
 
-	// Mark as processed
 	processed[key] = true
 
-	// Create a merged configuration
 	mergedConfig := &Brews{
 		Brews: make([]string, 0),
 		Taps:  make([]string, 0),
@@ -77,22 +67,13 @@ func mergeIncludes(cm map[string]*Brews, key string, processed map[string]bool) 
 		MAS:   make([]string, 0),
 	}
 
-	// Recursively process includes first
 	for _, include := range config.Includes {
-		includedConfig := mergeIncludes(cm, include, processed)
-		if includedConfig != nil {
-			mergedConfig.Brews = append(mergedConfig.Brews, includedConfig.Brews...)
-			mergedConfig.Taps = append(mergedConfig.Taps, includedConfig.Taps...)
-			mergedConfig.Casks = append(mergedConfig.Casks, includedConfig.Casks...)
-			mergedConfig.MAS = append(mergedConfig.MAS, includedConfig.MAS...)
+		if included := mergeIncludes(cm, include, processed); included != nil {
+			mergedConfig.merge(included)
 		}
 	}
 
-	// Add current config items
-	mergedConfig.Brews = append(mergedConfig.Brews, config.Brews...)
-	mergedConfig.Taps = append(mergedConfig.Taps, config.Taps...)
-	mergedConfig.Casks = append(mergedConfig.Casks, config.Casks...)
-	mergedConfig.MAS = append(mergedConfig.MAS, config.MAS...)
+	mergedConfig.merge(config)
 
 	return mergedConfig
 }

--- a/internal/core/config_brew.go
+++ b/internal/core/config_brew.go
@@ -1,95 +1,12 @@
 package core
 
-import (
-	"fmt"
-	"strings"
-)
-
 type Brews struct {
 	Remove   bool     `yaml:"remove"`
-	Outfile  string   `yaml:"outfile"`
 	Includes []string `yaml:"includes"`
 	Brews    []string `yaml:"brews"`
 	Taps     []string `yaml:"taps"`
 	Casks    []string `yaml:"casks"`
 	MAS      []string `yaml:"mas"`
-}
-
-// String returns a shell script to install the taps and brews
-func (c *Brews) String() string {
-	var script strings.Builder
-
-	script.WriteString(`#!/bin/bash
-
-# Exit immediately if a command exits with a non-zero status
-set -e
-# Exit if any command in a pipeline fails (not just the last one)
-set -o pipefail
-# Treat unset variables as an error when substituting
-set -u
-`)
-
-	actionTap := "tap"
-	actionInstall := "install"
-	if c.Remove {
-		actionTap = "untap"
-		actionInstall = "uninstall"
-	}
-
-	// Add taps - all in one command if there are any
-	if len(c.Taps) > 0 {
-		script.WriteString("# Adding Homebrew Taps\n")
-		for _, tap := range c.Taps {
-			script.WriteString(fmt.Sprintf("brew %s %s\n", actionTap, tap))
-		}
-		script.WriteString("\n")
-	}
-
-	// Install brews - all in one command if there are any
-	if len(c.Brews) > 0 {
-		script.WriteString("# Installing Homebrew Packages\n")
-		if len(c.Brews) == 1 {
-			script.WriteString(fmt.Sprintf("brew %s %s\n", actionInstall, c.Brews[0]))
-		} else {
-			script.WriteString(fmt.Sprintf("brew %s \\\n", actionInstall))
-			for i, brew := range c.Brews {
-				if i == len(c.Brews)-1 {
-					script.WriteString(fmt.Sprintf("  %s\n", brew))
-				} else {
-					script.WriteString(fmt.Sprintf("  %s \\\n", brew))
-				}
-			}
-		}
-		script.WriteString("\n")
-	}
-
-	// Install casks - all in one command if there are any
-	if len(c.Casks) > 0 {
-		script.WriteString("# Installing Homebrew Casks\n")
-		if len(c.Casks) == 1 {
-			script.WriteString(fmt.Sprintf("brew %s --cask %s\n", actionInstall, c.Casks[0]))
-		} else {
-			script.WriteString(fmt.Sprintf("brew %s --cask \\\n", actionInstall))
-			for i, cask := range c.Casks {
-				if i == len(c.Casks)-1 {
-					script.WriteString(fmt.Sprintf("  %s\n", cask))
-				} else {
-					script.WriteString(fmt.Sprintf("  %s \\\n", cask))
-				}
-			}
-		}
-		script.WriteString("\n")
-	}
-
-	// Install Mac App Store apps - unfortunately mas doesn't support batch installs
-	if len(c.MAS) > 0 {
-		script.WriteString("# Installing Mac App Store Apps\n")
-		for _, app := range c.MAS {
-			script.WriteString(fmt.Sprintf("mas install %s\n", app))
-		}
-	}
-
-	return script.String()
 }
 
 type ConfigMap map[string]*Brews
@@ -109,9 +26,8 @@ func (cm ConfigMap) Get(key string) *Brews {
 
 	// Merge included configurations
 	mergedConfig := &Brews{
-		Remove:  baseConfig.Remove,
-		Outfile: baseConfig.Outfile,
-		Brews:   make([]string, 0),
+		Remove: baseConfig.Remove,
+		Brews:  make([]string, 0),
 		Taps:    make([]string, 0),
 		Casks:   make([]string, 0),
 		MAS:     make([]string, 0),

--- a/internal/core/config_brew_test.go
+++ b/internal/core/config_brew_test.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestConfigMap_Get_NotFound(t *testing.T) {
+	cm := ConfigMap{}
+	if got := cm.Get("missing"); got != nil {
+		t.Errorf("Get(missing) = %v, want nil", got)
+	}
+}
+
+func TestConfigMap_Get_NoIncludes(t *testing.T) {
+	cm := ConfigMap{
+		"simple": {
+			Taps:  []string{"tap1"},
+			Brews: []string{"pkg1"},
+		},
+	}
+
+	got := cm.Get("simple")
+	if got == nil {
+		t.Fatal("Get(simple) = nil")
+	}
+	if len(got.Taps) != 1 || got.Taps[0] != "tap1" {
+		t.Errorf("Taps = %v, want [tap1]", got.Taps)
+	}
+	if len(got.Brews) != 1 || got.Brews[0] != "pkg1" {
+		t.Errorf("Brews = %v, want [pkg1]", got.Brews)
+	}
+}
+
+func TestConfigMap_Get_WithIncludes(t *testing.T) {
+	cm := ConfigMap{
+		"base": {
+			Brews: []string{"curl"},
+			Taps:  []string{"base/tap"},
+		},
+		"extended": {
+			Includes: []string{"base"},
+			Brews:    []string{"git"},
+			Casks:    []string{"firefox"},
+		},
+	}
+
+	got := cm.Get("extended")
+	if got == nil {
+		t.Fatal("Get(extended) = nil")
+	}
+
+	// Included items come first, then the base config's own items
+	wantBrews := []string{"curl", "git"}
+	if len(got.Brews) != len(wantBrews) {
+		t.Fatalf("Brews = %v, want %v", got.Brews, wantBrews)
+	}
+	for i, want := range wantBrews {
+		if got.Brews[i] != want {
+			t.Errorf("Brews[%d] = %q, want %q", i, got.Brews[i], want)
+		}
+	}
+
+	if len(got.Taps) != 1 || got.Taps[0] != "base/tap" {
+		t.Errorf("Taps = %v, want [base/tap]", got.Taps)
+	}
+	if len(got.Casks) != 1 || got.Casks[0] != "firefox" {
+		t.Errorf("Casks = %v, want [firefox]", got.Casks)
+	}
+}
+
+func TestConfigMap_Get_CircularIncludes(t *testing.T) {
+	cm := ConfigMap{
+		"a": {
+			Includes: []string{"b"},
+			Brews:    []string{"pkg-a"},
+		},
+		"b": {
+			Includes: []string{"a"},
+			Brews:    []string{"pkg-b"},
+		},
+	}
+
+	// Should not infinite loop; circular reference is broken
+	got := cm.Get("a")
+	if got == nil {
+		t.Fatal("Get(a) = nil")
+	}
+
+	// "b" is included into "a", but "b" trying to include "a" is skipped
+	wantBrews := []string{"pkg-b", "pkg-a"}
+	if len(got.Brews) != len(wantBrews) {
+		t.Fatalf("Brews = %v, want %v", got.Brews, wantBrews)
+	}
+	for i, want := range wantBrews {
+		if got.Brews[i] != want {
+			t.Errorf("Brews[%d] = %q, want %q", i, got.Brews[i], want)
+		}
+	}
+}
+
+func TestConfigMap_Get_PreservesRemove(t *testing.T) {
+	cm := ConfigMap{
+		"cleanup": {
+			Remove: true,
+			Brews:  []string{"oldpkg"},
+		},
+	}
+
+	got := cm.Get("cleanup")
+	if got == nil {
+		t.Fatal("Get(cleanup) = nil")
+	}
+	if !got.Remove {
+		t.Error("Remove = false, want true")
+	}
+}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -8,6 +8,39 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
+func TestConfigFile_VersionDefault(t *testing.T) {
+	// Config without version field should default to 1
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mmdot.yml")
+	if err := os.WriteFile(cfgPath, []byte("templates: []\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	cfg, err := SetupEnv(cfgPath)
+	if err != nil {
+		t.Fatalf("SetupEnv() error: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1", cfg.Version)
+	}
+}
+
+func TestConfigFile_VersionExplicit(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mmdot.yml")
+	if err := os.WriteFile(cfgPath, []byte("version: 2\ntemplates: []\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	cfg, err := SetupEnv(cfgPath)
+	if err != nil {
+		t.Fatalf("SetupEnv() error: %v", err)
+	}
+	if cfg.Version != 2 {
+		t.Errorf("Version = %d, want 2", cfg.Version)
+	}
+}
+
 func TestAgeFile_YAMLParsing(t *testing.T) {
 	input := `
 recipients:

--- a/internal/core/path_resolver_test.go
+++ b/internal/core/path_resolver_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestPathResolver_Resolve(t *testing.T) {
+	// Ensure we're in a valid directory for tests that call os.Getwd()
+	// (CI runners may delete the working directory between steps)
+	t.Chdir(t.TempDir())
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("failed to get home directory: %v", err)

--- a/internal/generator/engine.go
+++ b/internal/generator/engine.go
@@ -39,8 +39,13 @@ func (e *Engine) RenderTemplate(ctx context.Context, tmpl core.Template) error {
 		}
 	}
 
-	// Parse and execute template
-	t := template.New(tmpl.Name)
+	// Parse built-in partials, then the user's template
+	t := template.New(tmpl.Name).Funcs(e.funcMap())
+	for name, body := range builtinPartials {
+		if _, err := t.New(name).Parse(body); err != nil {
+			return fmt.Errorf("failed to parse builtin partial %q: %w", name, err)
+		}
+	}
 	t, err := t.Parse(tmpl.Template)
 	if err != nil {
 		return NewTemplateError(tmpl.Name, err)
@@ -173,6 +178,60 @@ func (e *Engine) loadVarsFile(vf core.VarFile, identity age.Identity) (map[strin
 	}
 
 	return vars, nil
+}
+
+// builtinPartials are named templates automatically available in all user templates.
+// Invoke with {{template "name" arg}}.
+var builtinPartials = map[string]string{
+	// brewfile renders brew tap/install/uninstall commands for a named brew config.
+	// Usage: {{template "brewfile" "personal"}}
+	// The argument is the brew config key from the brews: section in mmdot.yml.
+	"brewfile": `
+{{- $b := brewConfig . -}}
+{{- $tap := "tap" -}}{{- $install := "install" -}}
+{{- if $b.Remove -}}{{- $tap = "untap" -}}{{- $install = "uninstall" -}}{{- end -}}
+{{- if $b.Taps -}}
+# Homebrew Taps
+{{range $b.Taps -}}
+brew {{$tap}} {{.}}
+{{end}}
+{{end -}}
+{{- if $b.Brews -}}
+# Homebrew Packages
+{{range $b.Brews -}}
+brew {{$install}} {{.}}
+{{end}}
+{{end -}}
+{{- if $b.Casks -}}
+# Homebrew Casks
+{{range $b.Casks -}}
+brew {{$install}} --cask {{.}}
+{{end}}
+{{end -}}
+{{- if $b.MAS -}}
+# Mac App Store
+{{range $b.MAS -}}
+mas install {{.}}
+{{end}}
+{{end -}}`,
+}
+
+// funcMap returns template functions available to all templates.
+func (e *Engine) funcMap() template.FuncMap {
+	return template.FuncMap{
+		// brewConfig resolves a named brew configuration (with includes merged)
+		// and returns it for use in templates.
+		//
+		// Usage: {{$b := brewConfig "personal"}}
+		//        {{range $b.Taps}}brew tap {{.}}{{end}}
+		"brewConfig": func(name string) (*core.Brews, error) {
+			b := e.cfg.Brews.Get(name)
+			if b == nil {
+				return nil, fmt.Errorf("brew config %q not found", name)
+			}
+			return b, nil
+		},
+	}
 }
 
 // MergeMaps merges multiple maps with later maps taking precedence over earlier ones.

--- a/internal/generator/engine.go
+++ b/internal/generator/engine.go
@@ -3,10 +3,12 @@ package generator
 import (
 	"bytes"
 	"context"
+	"embed"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"filippo.io/age"
@@ -16,9 +18,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+//go:embed partials/*.txt
+var partialsFS embed.FS
+
 type Engine struct {
 	cfg *core.ConfigFile
 
+	varsLoaded bool
 	globalVars map[string]any
 	fileVars   map[string]any
 }
@@ -32,8 +38,7 @@ func NewEngine(cfg *core.ConfigFile) *Engine {
 }
 
 func (e *Engine) RenderTemplate(ctx context.Context, tmpl core.Template) error {
-	// Preload variables if not already done
-	if len(e.globalVars) == 0 && len(e.fileVars) == 0 {
+	if !e.varsLoaded {
 		if err := e.preloadVars(); err != nil {
 			return fmt.Errorf("failed to preload vars: %w", err)
 		}
@@ -94,7 +99,7 @@ func (e *Engine) RenderTemplate(ctx context.Context, tmpl core.Template) error {
 // this sets the globalVars and fileVars properties and should be called before
 // rendering a template.
 func (e *Engine) preloadVars() error {
-	// Load global vars
+	e.varsLoaded = true
 	e.globalVars = e.cfg.Variables.Vars
 
 	// Load identity for encrypted files
@@ -180,40 +185,34 @@ func (e *Engine) loadVarsFile(vf core.VarFile, identity age.Identity) (map[strin
 	return vars, nil
 }
 
-// builtinPartials are named templates automatically available in all user templates.
+// builtinPartials are named templates loaded from embedded files in partials/.
+// Each file becomes a partial named after the filename without extension.
 // Invoke with {{template "name" arg}}.
-var builtinPartials = map[string]string{
-	// brewfile renders brew tap/install/uninstall commands for a named brew config.
-	// Usage: {{template "brewfile" "personal"}}
-	// The argument is the brew config key from the brews: section in mmdot.yml.
-	"brewfile": `
-{{- $b := brewConfig . -}}
-{{- $tap := "tap" -}}{{- $install := "install" -}}
-{{- if $b.Remove -}}{{- $tap = "untap" -}}{{- $install = "uninstall" -}}{{- end -}}
-{{- if $b.Taps -}}
-# Homebrew Taps
-{{range $b.Taps -}}
-brew {{$tap}} {{.}}
-{{end}}
-{{end -}}
-{{- if $b.Brews -}}
-# Homebrew Packages
-{{range $b.Brews -}}
-brew {{$install}} {{.}}
-{{end}}
-{{end -}}
-{{- if $b.Casks -}}
-# Homebrew Casks
-{{range $b.Casks -}}
-brew {{$install}} --cask {{.}}
-{{end}}
-{{end -}}
-{{- if $b.MAS -}}
-# Mac App Store
-{{range $b.MAS -}}
-mas install {{.}}
-{{end}}
-{{end -}}`,
+var builtinPartials = mustLoadPartials()
+
+func mustLoadPartials() map[string]string {
+	partials := map[string]string{}
+
+	entries, err := partialsFS.ReadDir("partials")
+	if err != nil {
+		panic("failed to read embedded partials: " + err.Error())
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		data, err := partialsFS.ReadFile("partials/" + entry.Name())
+		if err != nil {
+			panic("failed to read partial " + entry.Name() + ": " + err.Error())
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".txt")
+		partials[name] = string(data)
+	}
+
+	return partials
 }
 
 // funcMap returns template functions available to all templates.

--- a/internal/generator/engine_test.go
+++ b/internal/generator/engine_test.go
@@ -79,6 +79,7 @@ func TestBrewfilePartialRemove(t *testing.T) {
 				Taps:   []string{"old/tap"},
 				Brews:  []string{"oldpkg"},
 				Casks:  []string{"oldcask"},
+				MAS:    []string{"123456"},
 			},
 		},
 		Variables: core.Variables{},
@@ -108,6 +109,7 @@ func TestBrewfilePartialRemove(t *testing.T) {
 		"brew untap old/tap",
 		"brew uninstall oldpkg",
 		"brew uninstall --cask oldcask",
+		"mas uninstall 123456",
 	} {
 		if !bytes.Contains(got, []byte(want)) {
 			t.Errorf("output missing %q\n\ngot:\n%s", want, output)

--- a/internal/generator/engine_test.go
+++ b/internal/generator/engine_test.go
@@ -1,0 +1,139 @@
+package generator
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hay-kot/mmdot/internal/core"
+)
+
+func TestBrewfilePartial(t *testing.T) {
+	dir := t.TempDir()
+	outfile := filepath.Join(dir, "brew.sh")
+
+	cfg := &core.ConfigFile{
+		Brews: core.ConfigMap{
+			"base": &core.Brews{
+				Brews: []string{"curl", "wget"},
+			},
+			"personal": &core.Brews{
+				Includes: []string{"base"},
+				Taps:     []string{"homebrew/cask"},
+				Brews:    []string{"git", "vim"},
+				Casks:    []string{"firefox"},
+				MAS:      []string{"497799835"},
+			},
+		},
+		Variables: core.Variables{},
+	}
+
+	engine := NewEngine(cfg)
+
+	tmpl := core.Template{
+		Name:   "test-brewfile",
+		Output: outfile,
+		Template: `#!/bin/bash
+set -euo pipefail
+{{template "brewfile" "personal"}}`,
+	}
+
+	err := engine.RenderTemplate(context.Background(), tmpl)
+	if err != nil {
+		t.Fatalf("RenderTemplate failed: %v", err)
+	}
+
+	got, err := os.ReadFile(outfile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	output := string(got)
+
+	// Verify includes are resolved (base brews merged in)
+	for _, want := range []string{
+		"brew tap homebrew/cask",
+		"brew install curl",
+		"brew install wget",
+		"brew install git",
+		"brew install vim",
+		"brew install --cask firefox",
+		"mas install 497799835",
+	} {
+		if !bytes.Contains(got, []byte(want)) {
+			t.Errorf("output missing %q\n\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestBrewfilePartialRemove(t *testing.T) {
+	dir := t.TempDir()
+	outfile := filepath.Join(dir, "brew-remove.sh")
+
+	cfg := &core.ConfigFile{
+		Brews: core.ConfigMap{
+			"cleanup": &core.Brews{
+				Remove: true,
+				Taps:   []string{"old/tap"},
+				Brews:  []string{"oldpkg"},
+				Casks:  []string{"oldcask"},
+			},
+		},
+		Variables: core.Variables{},
+	}
+
+	engine := NewEngine(cfg)
+
+	tmpl := core.Template{
+		Name:     "test-remove",
+		Output:   outfile,
+		Template: `{{template "brewfile" "cleanup"}}`,
+	}
+
+	err := engine.RenderTemplate(context.Background(), tmpl)
+	if err != nil {
+		t.Fatalf("RenderTemplate failed: %v", err)
+	}
+
+	got, err := os.ReadFile(outfile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	output := string(got)
+
+	for _, want := range []string{
+		"brew untap old/tap",
+		"brew uninstall oldpkg",
+		"brew uninstall --cask oldcask",
+	} {
+		if !bytes.Contains(got, []byte(want)) {
+			t.Errorf("output missing %q\n\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestBrewfilePartialUnknownConfig(t *testing.T) {
+	dir := t.TempDir()
+	outfile := filepath.Join(dir, "out.sh")
+
+	cfg := &core.ConfigFile{
+		Brews:     core.ConfigMap{},
+		Variables: core.Variables{},
+	}
+
+	engine := NewEngine(cfg)
+
+	tmpl := core.Template{
+		Name:     "test-unknown",
+		Output:   outfile,
+		Template: `{{template "brewfile" "nonexistent"}}`,
+	}
+
+	err := engine.RenderTemplate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatal("expected error for unknown brew config, got nil")
+	}
+}

--- a/internal/generator/partials/brewfile.txt
+++ b/internal/generator/partials/brewfile.txt
@@ -1,0 +1,28 @@
+
+{{- $b := brewConfig . -}}
+{{- $tap := "tap" -}}{{- $install := "install" -}}
+{{- if $b.Remove -}}{{- $tap = "untap" -}}{{- $install = "uninstall" -}}{{- end -}}
+{{- if $b.Taps -}}
+# Homebrew Taps
+{{range $b.Taps -}}
+brew {{$tap}} {{.}}
+{{end}}
+{{end -}}
+{{- if $b.Brews -}}
+# Homebrew Packages
+{{range $b.Brews -}}
+brew {{$install}} {{.}}
+{{end}}
+{{end -}}
+{{- if $b.Casks -}}
+# Homebrew Casks
+{{range $b.Casks -}}
+brew {{$install}} --cask {{.}}
+{{end}}
+{{end -}}
+{{- if $b.MAS -}}
+# Mac App Store
+{{range $b.MAS -}}
+mas {{if $b.Remove}}uninstall{{else}}install{{end}} {{.}}
+{{end}}
+{{end -}}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -1,0 +1,52 @@
+// Package migrations contains config version migration notes.
+// Each entry describes what changed from the previous version and how to update.
+package migrations
+
+// Note describes a single config version migration.
+type Note struct {
+	// Version is the target version (e.g., 2 means "changes from v1 to v2").
+	Version int
+	// Summary is a short description of the migration for listing.
+	Summary string
+	// Body is the full migration guide in markdown.
+	Body string
+}
+
+// Notes is the ordered list of all config migrations.
+// Add new entries at the end when bumping core.ConfigVersion.
+var Notes = []Note{
+	{
+		Version: 2,
+		Summary: "Brew file generation moved to templates",
+		Body: `### Migrate v1 → v2: Brew file generation moved to templates
+
+**Removed:**
+- ` + "`brew compile`" + ` subcommand
+- ` + "`brews.*.outfile`" + ` config field
+- Hardcoded Brewfile script generation
+
+**Added:**
+- ` + "`brewConfig`" + ` template function: resolves a named brew config (with includes) and returns the Brews struct
+- ` + "`brewfile`" + ` built-in partial: renders brew tap/install/cask/mas commands
+
+**Migration steps:**
+1. Remove any ` + "`outfile`" + ` fields from your ` + "`brews:`" + ` config entries
+2. Add a template entry for each brew config that had an outfile:
+
+` + "```yaml" + `
+templates:
+  - name: brew-personal
+    tags: [brew]
+    output: ./generated/brew-personal.sh
+    perm: "0755"
+    template: |
+      #!/bin/bash
+      set -euo pipefail
+      {{template "brewfile" "personal"}}
+` + "```" + `
+
+3. Set ` + "`version: 2`" + ` in your config file
+4. Run ` + "`mmdot generate`" + ` instead of ` + "`mmdot brew compile`" + `
+`,
+	},
+}

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 		commands.NewBrewCmd(flags),
 		commands.NewEncryptCmd(flags),
 		commands.NewHookCmd(flags),
+		commands.NewLLMTextCmd(flags),
 	)
 
 	exitCode := 0


### PR DESCRIPTION
## Summary

- Remove `brew compile` subcommand and `Brews.String()` script generator
- Add `brewConfig` template function that resolves a named brew config (with includes merged) and returns the `Brews` struct
- Add built-in `brewfile` partial template that renders tap/install/cask/mas commands, respecting the `remove` flag
- Remove `Outfile` field from `Brews` struct

Brew install scripts are now generated through the existing template engine instead of a bespoke code path. Usage:

```yaml
templates:
  - name: brew-personal
    tags: [brew]
    output: ./generated/brew-personal.sh
    perm: "0755"
    template: |
      #!/bin/bash
      set -euo pipefail
      {{template "brewfile" "personal"}}
```

## Test plan
- [x] Added tests for brewfile partial (install, remove, unknown config error)
- [x] `task pr` passes (tidy, lint, 54 tests)