### PR TITLE
fix: support multiple age recipients and prevent partial files on failure

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"filippo.io/age"
 	"github.com/hay-kot/mmdot/internal/core"
 	"github.com/hay-kot/mmdot/pkgs/fcrypt"
 	"github.com/rs/zerolog/log"
@@ -148,9 +147,9 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("no age recipients configured in mmdot.yaml")
 	}
 
-	recipient, err := fcrypt.LoadPublicKey(cfg.Age.Recipients[0])
+	recipients, err := fcrypt.LoadPublicKeys(cfg.Age.Recipients)
 	if err != nil {
-		return fmt.Errorf("failed to load public key: %w", err)
+		return fmt.Errorf("failed to load public keys: %w", err)
 	}
 
 	// Encrypt vault files
@@ -162,7 +161,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Encrypting vault file")
-		if err := fcrypt.EncryptFile(sourceFile, targetFile, []age.Recipient{recipient}); err != nil {
+		if err := fcrypt.EncryptFile(sourceFile, targetFile, recipients); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", sourceFile, err)
 		}
 		log.Info().Str("file", targetFile).Msg("Vault file encrypted successfully")
@@ -175,7 +174,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		log.Info().Str("source", af.Dest).Str("target", af.Src).Msg("Encrypting age file")
-		if err := fcrypt.EncryptFile(af.Dest, af.Src, []age.Recipient{recipient}); err != nil {
+		if err := fcrypt.EncryptFile(af.Dest, af.Src, recipients); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", af.Dest, err)
 		}
 		log.Info().Str("file", af.Src).Msg("Age file encrypted successfully")

--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"filippo.io/age"
 	"github.com/hay-kot/mmdot/internal/core"
 	"github.com/hay-kot/mmdot/pkgs/fcrypt"
 	"github.com/rs/zerolog/log"
@@ -161,7 +162,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		log.Info().Str("source", sourceFile).Str("target", targetFile).Msg("Encrypting vault file")
-		if err := fcrypt.EncryptFile(sourceFile, targetFile, recipient); err != nil {
+		if err := fcrypt.EncryptFile(sourceFile, targetFile, []age.Recipient{recipient}); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", sourceFile, err)
 		}
 		log.Info().Str("file", targetFile).Msg("Vault file encrypted successfully")
@@ -174,7 +175,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		log.Info().Str("source", af.Dest).Str("target", af.Src).Msg("Encrypting age file")
-		if err := fcrypt.EncryptFile(af.Dest, af.Src, recipient); err != nil {
+		if err := fcrypt.EncryptFile(af.Dest, af.Src, []age.Recipient{recipient}); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", af.Dest, err)
 		}
 		log.Info().Str("file", af.Src).Msg("Age file encrypted successfully")

--- a/pkgs/fcrypt/file_handlers.go
+++ b/pkgs/fcrypt/file_handlers.go
@@ -13,7 +13,7 @@ import (
 // without confirmation and cannot be recovered.
 func EncryptInPlace(filepath string, pubkey age.Recipient) error {
 	outputPath := filepath + ".age"
-	return EncryptFile(filepath, outputPath, pubkey)
+	return EncryptFile(filepath, outputPath, []age.Recipient{pubkey})
 }
 
 // DecryptInPlace takes in a file that is assumed to be encrypted and replaces that file

--- a/pkgs/fcrypt/file_handlers.go
+++ b/pkgs/fcrypt/file_handlers.go
@@ -11,9 +11,9 @@ import (
 // EncryptInPlace takes a filepath <name>.<ext>. This file is then replaced with an
 // encrypted version with a new file <name>.<ext>.age. The old file is removed
 // without confirmation and cannot be recovered.
-func EncryptInPlace(filepath string, pubkey age.Recipient) error {
+func EncryptInPlace(filepath string, recipients []age.Recipient) error {
 	outputPath := filepath + ".age"
-	return EncryptFile(filepath, outputPath, []age.Recipient{pubkey})
+	return EncryptFile(filepath, outputPath, recipients)
 }
 
 // DecryptInPlace takes in a file that is assumed to be encrypted and replaces that file

--- a/pkgs/fcrypt/io_handlers.go
+++ b/pkgs/fcrypt/io_handlers.go
@@ -106,9 +106,10 @@ func DecryptReader(r io.Reader, w io.Writer, identity age.Identity) error {
 	return nil
 }
 
-// DecryptFile decrypts a file leaving the original
-func DecryptFile(inputPath, outputPath string, identity age.Identity) error {
-	// Open input file
+// DecryptFile decrypts a file leaving the original.
+// It writes to a temporary file first and renames on success to avoid
+// leaving a partially-written output file on failure.
+func DecryptFile(inputPath, outputPath string, identity age.Identity) (err error) {
 	inputFile, err := os.Open(inputPath)
 	if err != nil {
 		return fmt.Errorf("failed to open input file: %w", err)
@@ -117,18 +118,27 @@ func DecryptFile(inputPath, outputPath string, identity age.Identity) error {
 		_ = inputFile.Close()
 	}()
 
-	// Create output file
-	outputFile, err := os.Create(outputPath)
+	tmpFile, err := os.CreateTemp(filepath.Dir(outputPath), ".mmdot-decrypt-*")
 	if err != nil {
-		return fmt.Errorf("failed to create output file: %w", err)
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() {
-		_ = outputFile.Close()
+		if err != nil {
+			_ = os.Remove(tmpFile.Name())
+		}
 	}()
 
-	// Use DecryptReader to handle the decryption
-	if err := DecryptReader(inputFile, outputFile, identity); err != nil {
+	if err = DecryptReader(inputFile, tmpFile, identity); err != nil {
+		_ = tmpFile.Close()
 		return err
+	}
+
+	if err = tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpFile.Name(), outputPath); err != nil {
+		return fmt.Errorf("failed to rename temp file to output: %w", err)
 	}
 
 	return nil

--- a/pkgs/fcrypt/io_handlers.go
+++ b/pkgs/fcrypt/io_handlers.go
@@ -10,14 +10,14 @@ import (
 )
 
 // EncryptReader encrypts data from an io.Reader and writes the encrypted result to an io.Writer
-func EncryptReader(r io.Reader, w io.Writer, recipient age.Recipient) error {
+func EncryptReader(r io.Reader, w io.Writer, recipients []age.Recipient) error {
 	armorWriter := armor.NewWriter(w)
 	defer func() {
 		_ = armorWriter.Close()
 	}()
 
 	// Create encryptor
-	encryptor, err := age.Encrypt(armorWriter, recipient)
+	encryptor, err := age.Encrypt(armorWriter, recipients...)
 	if err != nil {
 		return fmt.Errorf("failed to create encryptor: %w", err)
 	}
@@ -64,7 +64,7 @@ func EncryptFile(inputPath, outputPath string, recipient age.Recipient) error {
 	}()
 
 	// Use EncryptReader to handle the encryption
-	if err := EncryptReader(inputFile, outputFile, recipient); err != nil {
+	if err := EncryptReader(inputFile, outputFile, []age.Recipient{recipient}); err != nil {
 		return err
 	}
 

--- a/pkgs/fcrypt/io_handlers.go
+++ b/pkgs/fcrypt/io_handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"filippo.io/age"
 	"filippo.io/age/armor"
@@ -43,9 +44,10 @@ func EncryptReader(r io.Reader, w io.Writer, recipients []age.Recipient) error {
 	return nil
 }
 
-// EncryptFile encrypts a file in place removing the original version
-func EncryptFile(inputPath, outputPath string, recipient age.Recipient) error {
-	// Open input file
+// EncryptFile encrypts a file in place removing the original version.
+// It writes to a temporary file first and renames on success to avoid
+// leaving a partially-written output file on failure.
+func EncryptFile(inputPath, outputPath string, recipients []age.Recipient) (err error) {
 	inputFile, err := os.Open(inputPath)
 	if err != nil {
 		return fmt.Errorf("failed to open input file: %w", err)
@@ -54,21 +56,29 @@ func EncryptFile(inputPath, outputPath string, recipient age.Recipient) error {
 		_ = inputFile.Close()
 	}()
 
-	// Create output file
-	outputFile, err := os.Create(outputPath)
+	tmpFile, err := os.CreateTemp(filepath.Dir(outputPath), ".mmdot-encrypt-*")
 	if err != nil {
-		return fmt.Errorf("failed to create output file: %w", err)
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() {
-		_ = outputFile.Close()
+		if err != nil {
+			_ = os.Remove(tmpFile.Name())
+		}
 	}()
 
-	// Use EncryptReader to handle the encryption
-	if err := EncryptReader(inputFile, outputFile, []age.Recipient{recipient}); err != nil {
+	if err = EncryptReader(inputFile, tmpFile, recipients); err != nil {
+		_ = tmpFile.Close()
 		return err
 	}
 
-	// Delete the original file
+	if err = tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpFile.Name(), outputPath); err != nil {
+		return fmt.Errorf("failed to rename temp file to output: %w", err)
+	}
+
 	if err = os.Remove(inputPath); err != nil {
 		return err
 	}

--- a/pkgs/fcrypt/io_handlers_test.go
+++ b/pkgs/fcrypt/io_handlers_test.go
@@ -1,0 +1,145 @@
+package fcrypt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+)
+
+func TestEncryptDecryptRoundtrip_MultipleRecipients(t *testing.T) {
+	const numRecipients = 3
+	const plaintext = "the quick brown fox jumps over the lazy dog"
+
+	identities := make([]*age.X25519Identity, numRecipients)
+	recipients := make([]age.Recipient, numRecipients)
+	for i := range numRecipients {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("generate identity %d: %v", i, err)
+		}
+		identities[i] = id
+		recipients[i] = id.Recipient()
+	}
+
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "plain.txt")
+	encryptedPath := filepath.Join(tmpDir, "plain.txt.age")
+
+	if err := os.WriteFile(inputPath, []byte(plaintext), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	// Encrypt with all recipients.
+	if err := EncryptFile(inputPath, encryptedPath, recipients); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	// EncryptFile removes the input; verify it's gone.
+	if _, err := os.Stat(inputPath); !os.IsNotExist(err) {
+		t.Fatal("expected input file to be removed after encryption")
+	}
+
+	// Decrypt with each identity individually.
+	for i, id := range identities {
+		outPath := filepath.Join(tmpDir, "decrypted"+string(rune('0'+i))+".txt")
+		if err := DecryptFile(encryptedPath, outPath, id); err != nil {
+			t.Fatalf("DecryptFile with identity %d: %v", i, err)
+		}
+
+		got, err := os.ReadFile(outPath)
+		if err != nil {
+			t.Fatalf("read decrypted output %d: %v", i, err)
+		}
+		if string(got) != plaintext {
+			t.Errorf("identity %d: got %q, want %q", i, got, plaintext)
+		}
+	}
+}
+
+func TestEncryptFile_NoOutputOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistent := filepath.Join(tmpDir, "does-not-exist.txt")
+	outputPath := filepath.Join(tmpDir, "output.age")
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	err = EncryptFile(nonExistent, outputPath, []age.Recipient{id.Recipient()})
+	if err == nil {
+		t.Fatal("expected error for non-existent input")
+	}
+
+	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
+		t.Fatal("output file should not exist after encryption failure")
+	}
+
+	// Also verify no temp files leaked into the directory.
+	entries, _ := filepath.Glob(filepath.Join(tmpDir, ".mmdot-encrypt-*"))
+	if len(entries) > 0 {
+		t.Fatalf("temp files leaked: %v", entries)
+	}
+}
+
+func TestDecryptFile_NoOutputOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	badInput := filepath.Join(tmpDir, "not-encrypted.txt")
+	outputPath := filepath.Join(tmpDir, "decrypted.txt")
+
+	if err := os.WriteFile(badInput, []byte("this is not age-encrypted data"), 0o600); err != nil {
+		t.Fatalf("write bad input: %v", err)
+	}
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	err = DecryptFile(badInput, outputPath, id)
+	if err == nil {
+		t.Fatal("expected error for non-encrypted input")
+	}
+
+	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
+		t.Fatal("output file should not exist after decryption failure")
+	}
+
+	// Also verify no temp files leaked into the directory.
+	entries, _ := filepath.Glob(filepath.Join(tmpDir, ".mmdot-decrypt-*"))
+	if len(entries) > 0 {
+		t.Fatalf("temp files leaked: %v", entries)
+	}
+}
+
+func TestLoadPublicKeys(t *testing.T) {
+	const numKeys = 3
+
+	keyStrings := make([]string, numKeys)
+	for i := range numKeys {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("generate identity %d: %v", i, err)
+		}
+		keyStrings[i] = id.Recipient().String()
+	}
+
+	// Valid keys should all load.
+	got, err := LoadPublicKeys(keyStrings)
+	if err != nil {
+		t.Fatalf("LoadPublicKeys with valid keys: %v", err)
+	}
+	if len(got) != numKeys {
+		t.Fatalf("got %d recipients, want %d", len(got), numKeys)
+	}
+
+	// One invalid key mixed in should produce an error.
+	badKeys := append([]string{}, keyStrings...)
+	badKeys[1] = "not-a-valid-age-key"
+	_, err = LoadPublicKeys(badKeys)
+	if err == nil {
+		t.Fatal("expected error for invalid key in slice")
+	}
+}

--- a/pkgs/fcrypt/key_loaders.go
+++ b/pkgs/fcrypt/key_loaders.go
@@ -15,6 +15,20 @@ func LoadPublicKey(key string) (*age.X25519Recipient, error) {
 	return ageRecipient, nil
 }
 
+func LoadPublicKeys(keys []string) ([]age.Recipient, error) {
+	recipients := make([]age.Recipient, 0, len(keys))
+	for _, key := range keys {
+		recipient, err := LoadPublicKey(key)
+		if err != nil {
+			return nil, err
+		}
+
+		recipients = append(recipients, recipient)
+	}
+
+	return recipients, nil
+}
+
 func LoadPrivateKey(key string) (*age.X25519Identity, error) {
 	ageIdentity, err := age.ParseX25519Identity(key)
 	if err != nil {


### PR DESCRIPTION
## Summary

The encrypt path only used `Recipients[0]`, silently ignoring any additional configured recipients. Encrypt and decrypt operations also wrote directly to the output path, leaving empty or partial files on disk when they failed mid-operation.

This threads `[]age.Recipient` through the entire encrypt chain and switches both `EncryptFile` and `DecryptFile` to a temp-file-then-rename pattern. Tests cover multi-recipient roundtrip decryption and verify no leaked files on failure.