### PR TITLE
fix: encrypt --dry-run handles age.files when both src and dest exist

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -108,17 +108,38 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
 	}
 
-	// Collect age.files that need encryption (dest plaintext exists)
+	// Collect age.files that need encryption.
+	// A file needs encryption when:
+	//   - dest (plaintext) exists AND src (.age) does NOT exist, or
+	//   - dest (plaintext) is newer than src (.age)
 	ageFilesToEncrypt := []core.AgeFile{}
 	for _, af := range cfg.Age.Files {
-		if _, err := os.Stat(af.Dest); err != nil {
+		destInfo, err := os.Stat(af.Dest)
+		if err != nil {
 			if os.IsNotExist(err) {
 				log.Debug().Str("dest", af.Dest).Msg("Plaintext dest doesn't exist, skipping")
 				continue
 			}
 			return fmt.Errorf("failed to stat %s: %w", af.Dest, err)
 		}
-		ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+
+		srcInfo, err := os.Stat(af.Src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Plaintext exists but .age file doesn't — needs encryption
+				ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", af.Src, err)
+		}
+
+		// Both exist — only re-encrypt if plaintext is newer
+		if destInfo.ModTime().After(srcInfo.ModTime()) {
+			log.Debug().Str("dest", af.Dest).Str("src", af.Src).Msg("Plaintext is newer than encrypted, needs re-encryption")
+			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+		} else {
+			log.Debug().Str("dest", af.Dest).Str("src", af.Src).Msg("Encrypted file is up-to-date, skipping")
+		}
 	}
 
 	totalToEncrypt := len(vaultFilesToEncrypt) + len(ageFilesToEncrypt)

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -1,8 +1,14 @@
 package commands
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/hay-kot/mmdot/internal/core"
+	"github.com/urfave/cli/v3"
 )
 
 func chdir(t *testing.T, dir string) {
@@ -90,5 +96,147 @@ func Test_ensureGitignored_existingContentWithTrailingNewline(t *testing.T) {
 	want := "*.log\n" + path + "\n"
 	if string(data) != want {
 		t.Errorf(".gitignore content = %q, want %q", string(data), want)
+	}
+}
+
+// writeMinimalConfig writes a minimal mmdot.yml with the given age.files entries.
+func writeMinimalConfig(t *testing.T, dir string, ageFiles []core.AgeFile) {
+	t.Helper()
+
+	cfg := "version: 2\n"
+	if len(ageFiles) > 0 {
+		cfg += "age:\n  files:\n"
+		for _, af := range ageFiles {
+			cfg += "    - src: " + af.Src + "\n"
+			cfg += "      dest: " + af.Dest + "\n"
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "mmdot.yml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+}
+
+// writeFile creates a file with content and optional modtime.
+func writeFile(t *testing.T, path string, content string, modTime ...time.Time) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create dirs for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+	if len(modTime) > 0 {
+		if err := os.Chtimes(path, modTime[0], modTime[0]); err != nil {
+			t.Fatalf("failed to set modtime on %s: %v", path, err)
+		}
+	}
+}
+
+// runEncryptDryRun sets up an EncryptCmd with --dry-run and invokes encrypt.
+func runEncryptDryRun(t *testing.T, configPath string) error {
+	t.Helper()
+
+	flags := &core.Flags{ConfigFilePath: configPath}
+	ec := &EncryptCmd{coreFlags: flags, dryRun: true}
+
+	return ec.encrypt(context.Background(), &cli.Command{})
+}
+
+func TestEncryptDryRun_AgeFiles_BothExist_SrcNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	now := time.Now()
+	srcPath := filepath.Join(tmpDir, "secrets", "file.age")
+	destPath := filepath.Join(tmpDir, "output", "file.txt")
+
+	writeMinimalConfig(t, tmpDir, []core.AgeFile{
+		{Src: srcPath, Dest: destPath},
+	})
+
+	// src (.age) is newer than dest (plaintext) — normal post-decrypt state
+	writeFile(t, destPath, "plaintext", now.Add(-time.Minute))
+	writeFile(t, srcPath, "encrypted", now)
+
+	err := runEncryptDryRun(t, filepath.Join(tmpDir, "mmdot.yml"))
+	if err != nil {
+		t.Errorf("expected no error when .age src is newer, got: %v", err)
+	}
+}
+
+func TestEncryptDryRun_AgeFiles_BothExist_DestNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	now := time.Now()
+	srcPath := filepath.Join(tmpDir, "secrets", "file.age")
+	destPath := filepath.Join(tmpDir, "output", "file.txt")
+
+	writeMinimalConfig(t, tmpDir, []core.AgeFile{
+		{Src: srcPath, Dest: destPath},
+	})
+
+	// dest (plaintext) is newer than src (.age) — user edited the plaintext
+	writeFile(t, srcPath, "encrypted", now.Add(-time.Minute))
+	writeFile(t, destPath, "modified plaintext", now)
+
+	err := runEncryptDryRun(t, filepath.Join(tmpDir, "mmdot.yml"))
+	if err == nil {
+		t.Error("expected error when plaintext is newer than .age, got nil")
+	}
+}
+
+func TestEncryptDryRun_AgeFiles_OnlyDestExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "secrets", "file.age")
+	destPath := filepath.Join(tmpDir, "output", "file.txt")
+
+	writeMinimalConfig(t, tmpDir, []core.AgeFile{
+		{Src: srcPath, Dest: destPath},
+	})
+
+	// Only plaintext exists, no .age file — genuinely unencrypted
+	writeFile(t, destPath, "plaintext")
+
+	err := runEncryptDryRun(t, filepath.Join(tmpDir, "mmdot.yml"))
+	if err == nil {
+		t.Error("expected error when .age src doesn't exist, got nil")
+	}
+}
+
+func TestEncryptDryRun_AgeFiles_OnlySrcExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "secrets", "file.age")
+	destPath := filepath.Join(tmpDir, "output", "file.txt")
+
+	writeMinimalConfig(t, tmpDir, []core.AgeFile{
+		{Src: srcPath, Dest: destPath},
+	})
+
+	// Only .age exists, no plaintext — fully encrypted state
+	writeFile(t, srcPath, "encrypted")
+
+	err := runEncryptDryRun(t, filepath.Join(tmpDir, "mmdot.yml"))
+	if err != nil {
+		t.Errorf("expected no error when only .age src exists, got: %v", err)
+	}
+}
+
+func TestEncryptDryRun_AgeFiles_NeitherExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "secrets", "file.age")
+	destPath := filepath.Join(tmpDir, "output", "file.txt")
+
+	writeMinimalConfig(t, tmpDir, []core.AgeFile{
+		{Src: srcPath, Dest: destPath},
+	})
+
+	// Neither file exists — nothing to do
+	err := runEncryptDryRun(t, filepath.Join(tmpDir, "mmdot.yml"))
+	if err != nil {
+		t.Errorf("expected no error when neither file exists, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`encrypt --dry-run` (used by the pre-commit hook) incorrectly flagged age.files entries as needing encryption when both the `.age` src and plaintext dest existed simultaneously — the normal state after `mmdot decrypt`. Now compares modification times: skips when src is newer, flags for re-encryption when dest is newer.