### PR TITLE
fix: age.files encrypt --dry-run and preserve plaintext dest

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -108,17 +108,38 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
 	}
 
-	// Collect age.files that need encryption (dest plaintext exists)
+	// Collect age.files that need encryption.
+	// Only encrypt when:
+	//   1. Plaintext dest exists AND encrypted src does not (new file)
+	//   2. Plaintext dest is newer than encrypted src (modified file)
 	ageFilesToEncrypt := []core.AgeFile{}
 	for _, af := range cfg.Age.Files {
-		if _, err := os.Stat(af.Dest); err != nil {
+		destInfo, err := os.Stat(af.Dest)
+		if err != nil {
 			if os.IsNotExist(err) {
 				log.Debug().Str("dest", af.Dest).Msg("Plaintext dest doesn't exist, skipping")
 				continue
 			}
 			return fmt.Errorf("failed to stat %s: %w", af.Dest, err)
 		}
-		ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+
+		srcInfo, err := os.Stat(af.Src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Encrypted file missing — needs encryption
+				ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+				continue
+			}
+			return fmt.Errorf("failed to stat %s: %w", af.Src, err)
+		}
+
+		if destInfo.ModTime().After(srcInfo.ModTime()) {
+			// Plaintext is newer than encrypted — needs re-encryption
+			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+			continue
+		}
+
+		log.Debug().Str("src", af.Src).Str("dest", af.Dest).Msg("Encrypted file is up-to-date, skipping")
 	}
 
 	totalToEncrypt := len(vaultFilesToEncrypt) + len(ageFilesToEncrypt)
@@ -167,14 +188,14 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		log.Info().Str("file", targetFile).Msg("Vault file encrypted successfully")
 	}
 
-	// Encrypt age.files (dest -> src; EncryptFile removes the plaintext)
+	// Encrypt age.files (dest -> src; keep plaintext dest intact)
 	for _, af := range ageFilesToEncrypt {
 		if err := os.MkdirAll(filepath.Dir(af.Src), 0o755); err != nil {
 			return fmt.Errorf("failed to create parent dir for %s: %w", af.Src, err)
 		}
 
 		log.Info().Str("source", af.Dest).Str("target", af.Src).Msg("Encrypting age file")
-		if err := fcrypt.EncryptFile(af.Dest, af.Src, recipients); err != nil {
+		if err := fcrypt.EncryptFileKeepSource(af.Dest, af.Src, recipients); err != nil {
 			return fmt.Errorf("failed to encrypt %s: %w", af.Dest, err)
 		}
 		log.Info().Str("file", af.Src).Msg("Age file encrypted successfully")

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -2,7 +2,13 @@ package commands
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/hay-kot/mmdot/internal/core"
+	"github.com/hay-kot/mmdot/pkgs/fcrypt"
 )
 
 func chdir(t *testing.T, dir string) {
@@ -69,6 +75,196 @@ func Test_ensureGitignored_existingContentNoTrailingNewline(t *testing.T) {
 	want := "*.log\n" + path + "\n"
 	if string(data) != want {
 		t.Errorf(".gitignore content = %q, want %q", string(data), want)
+	}
+}
+
+// ageFileNeedsEncrypt mirrors the logic in encrypt() for age.files.
+// Returns true if the age file needs (re-)encryption.
+func ageFileNeedsEncrypt(af core.AgeFile) (bool, error) {
+	destInfo, err := os.Stat(af.Dest)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // no plaintext, nothing to encrypt
+		}
+		return false, err
+	}
+
+	srcInfo, err := os.Stat(af.Src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil // encrypted file missing
+		}
+		return false, err
+	}
+
+	return destInfo.ModTime().After(srcInfo.ModTime()), nil
+}
+
+func testRecipients(t *testing.T) (*age.X25519Identity, []age.Recipient) {
+	t.Helper()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	return id, []age.Recipient{id.Recipient()}
+}
+
+func TestAgeFileNeedsEncrypt_NoDest(t *testing.T) {
+	tmpDir := t.TempDir()
+	af := core.AgeFile{
+		Src:  filepath.Join(tmpDir, "secret.age"),
+		Dest: filepath.Join(tmpDir, "secret.json"),
+	}
+
+	needs, err := ageFileNeedsEncrypt(af)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needs {
+		t.Error("should not need encryption when plaintext dest doesn't exist")
+	}
+}
+
+func TestAgeFileNeedsEncrypt_DestExistsSrcMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "secret.json")
+	if err := os.WriteFile(destPath, []byte("plaintext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	af := core.AgeFile{
+		Src:  filepath.Join(tmpDir, "secret.age"),
+		Dest: destPath,
+	}
+
+	needs, err := ageFileNeedsEncrypt(af)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needs {
+		t.Error("should need encryption when .age file is missing")
+	}
+}
+
+func TestAgeFileNeedsEncrypt_BothExistSrcNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "secret.json")
+	srcPath := filepath.Join(tmpDir, "secret.age")
+
+	// Write dest first
+	if err := os.WriteFile(destPath, []byte("plaintext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set dest mtime to the past
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(destPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write src (encrypted) after — it's newer
+	if err := os.WriteFile(srcPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	af := core.AgeFile{Src: srcPath, Dest: destPath}
+
+	needs, err := ageFileNeedsEncrypt(af)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needs {
+		t.Error("should NOT need encryption when .age file is newer than plaintext")
+	}
+}
+
+func TestAgeFileNeedsEncrypt_BothExistDestNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "secret.json")
+	srcPath := filepath.Join(tmpDir, "secret.age")
+
+	// Write src first
+	if err := os.WriteFile(srcPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set src mtime to the past
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(srcPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write dest after — plaintext is newer
+	if err := os.WriteFile(destPath, []byte("plaintext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	af := core.AgeFile{Src: srcPath, Dest: destPath}
+
+	needs, err := ageFileNeedsEncrypt(af)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needs {
+		t.Error("should need re-encryption when plaintext is newer than .age file")
+	}
+}
+
+func TestEncryptFileKeepSource(t *testing.T) {
+	_, recipients := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "secret.json")
+	outputPath := filepath.Join(tmpDir, "secret.age")
+
+	const plaintext = "sensitive data"
+	if err := os.WriteFile(inputPath, []byte(plaintext), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fcrypt.EncryptFileKeepSource(inputPath, outputPath, recipients); err != nil {
+		t.Fatalf("EncryptFileKeepSource: %v", err)
+	}
+
+	// Plaintext source must still exist
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("plaintext source was deleted: %v", err)
+	}
+	if string(data) != plaintext {
+		t.Errorf("plaintext content changed: got %q, want %q", data, plaintext)
+	}
+
+	// Encrypted output must exist
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("encrypted output missing: %v", err)
+	}
+}
+
+func TestEncryptFileKeepSource_RoundTrip(t *testing.T) {
+	id, recipients := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "config.json")
+	encPath := filepath.Join(tmpDir, "config.age")
+	decPath := filepath.Join(tmpDir, "config-restored.json")
+
+	const plaintext = `{"key": "value"}`
+	if err := os.WriteFile(inputPath, []byte(plaintext), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fcrypt.EncryptFileKeepSource(inputPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFileKeepSource: %v", err)
+	}
+
+	if err := fcrypt.DecryptFile(encPath, decPath, id); err != nil {
+		t.Fatalf("DecryptFile: %v", err)
+	}
+
+	got, _ := os.ReadFile(decPath)
+	if string(got) != plaintext {
+		t.Errorf("round-trip failed: got %q, want %q", got, plaintext)
 	}
 }
 

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -210,6 +210,38 @@ func TestAgeFileNeedsEncrypt_BothExistDestNewer(t *testing.T) {
 	}
 }
 
+func TestAgeFileNeedsEncrypt_BothExistEqualMtime(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "secret.json")
+	srcPath := filepath.Join(tmpDir, "secret.age")
+
+	if err := os.WriteFile(srcPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destPath, []byte("plaintext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set both to the same mtime
+	now := time.Now()
+	if err := os.Chtimes(srcPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(destPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	af := core.AgeFile{Src: srcPath, Dest: destPath}
+
+	needs, err := ageFileNeedsEncrypt(af)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needs {
+		t.Error("should NOT need encryption when mtimes are equal")
+	}
+}
+
 func TestEncryptFileKeepSource(t *testing.T) {
 	_, recipients := testRecipients(t)
 

--- a/pkgs/fcrypt/io_handlers.go
+++ b/pkgs/fcrypt/io_handlers.go
@@ -44,10 +44,21 @@ func EncryptReader(r io.Reader, w io.Writer, recipients []age.Recipient) error {
 	return nil
 }
 
-// EncryptFile encrypts a file in place removing the original version.
+// EncryptFile encrypts a file, removing the original version.
 // It writes to a temporary file first and renames on success to avoid
 // leaving a partially-written output file on failure.
-func EncryptFile(inputPath, outputPath string, recipients []age.Recipient) (err error) {
+func EncryptFile(inputPath, outputPath string, recipients []age.Recipient) error {
+	return encryptFile(inputPath, outputPath, recipients, true)
+}
+
+// EncryptFileKeepSource encrypts a file, keeping the original intact.
+// Use this when the plaintext source lives outside the repository and
+// must not be deleted (e.g. age.files entries).
+func EncryptFileKeepSource(inputPath, outputPath string, recipients []age.Recipient) error {
+	return encryptFile(inputPath, outputPath, recipients, false)
+}
+
+func encryptFile(inputPath, outputPath string, recipients []age.Recipient, removeSource bool) (err error) {
 	inputFile, err := os.Open(inputPath)
 	if err != nil {
 		return fmt.Errorf("failed to open input file: %w", err)
@@ -79,8 +90,10 @@ func EncryptFile(inputPath, outputPath string, recipients []age.Recipient) (err 
 		return fmt.Errorf("failed to rename temp file to output: %w", err)
 	}
 
-	if err = os.Remove(inputPath); err != nil {
-		return err
+	if removeSource {
+		if err = os.Remove(inputPath); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fix encrypt --dry-run (pre-commit hook) falsely failing when both the .age source and plaintext dest exist simultaneously — the normal state after `mmdot decrypt`. Now checks whether the .age file is missing or the plaintext is newer via mtime comparison.

Also switches age.files encryption to preserve the plaintext dest file, since it may live outside the repo (e.g. `~/.config/`) and be needed by the tool that consumes it.