### PR TITLE
feat: add --force flag to mmdot encrypt

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -16,6 +16,7 @@ import (
 type EncryptCmd struct {
 	coreFlags *core.Flags
 	dryRun    bool
+	force     bool
 }
 
 func NewEncryptCmd(coreFlags *core.Flags) *EncryptCmd {
@@ -36,16 +37,26 @@ Files to encrypt are specified in mmdot.yaml under various sections like:
 The command will:
 - Use the configured age recipient (public key) for encryption
 - Create .age encrypted versions of the files
-- Skip files that are already encrypted
+- Skip files that are already encrypted (use --force to override)
 - Preserve original files after encryption
 
 Encrypted files use the age format and can only be decrypted with the
-corresponding age identity (private key).`,
+corresponding age identity (private key).
+
+Use --force to unconditionally re-encrypt every configured file, even
+if an up-to-date .age file already exists. This is useful when the
+existing .age files were encrypted to a different recipient set than
+the one currently configured.`,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:        "dry-run",
 					Usage:       "check if files need encryption without encrypting them",
 					Destination: &ec.dryRun,
+				},
+				&cli.BoolFlag{
+					Name:        "force",
+					Usage:       "re-encrypt every configured file regardless of whether an up-to-date .age file already exists",
+					Destination: &ec.force,
 				},
 			},
 			Action: ec.encrypt,
@@ -99,8 +110,11 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		if _, err := os.Stat(targetFile); err == nil {
-			log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, skipping")
-			continue
+			if !ec.force {
+				log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, skipping")
+				continue
+			}
+			log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, re-encrypting (--force)")
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("failed to stat %s: %w", targetFile, err)
 		}
@@ -133,8 +147,8 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to stat %s: %w", af.Src, err)
 		}
 
-		if destInfo.ModTime().After(srcInfo.ModTime()) {
-			// Plaintext is newer than encrypted — needs re-encryption
+		if ec.force || destInfo.ModTime().After(srcInfo.ModTime()) {
+			// Plaintext is newer than encrypted (or --force) — needs re-encryption
 			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
 			continue
 		}
@@ -146,16 +160,24 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 
 	if ec.dryRun {
 		if totalToEncrypt > 0 {
-			log.Error().Msg("Found unencrypted files:")
+			action := "needs encryption"
+			if ec.force {
+				action = "would be re-encrypted"
+			}
+			log.Error().Msgf("Found files that are %s:", action)
 			for _, file := range vaultFilesToEncrypt {
-				log.Error().Str("file", file).Msg("  - vault file needs encryption")
+				log.Error().Str("file", file).Msgf("  - vault file %s", action)
 			}
 			for _, af := range ageFilesToEncrypt {
-				log.Error().Str("dest", af.Dest).Str("src", af.Src).Msg("  - age file needs encryption")
+				log.Error().Str("dest", af.Dest).Str("src", af.Src).Msgf("  - age file %s", action)
 			}
-			return fmt.Errorf("found %d unencrypted file(s)", totalToEncrypt)
+			return fmt.Errorf("found %d file(s) that %s", totalToEncrypt, action)
 		}
-		log.Info().Msg("All files are encrypted")
+		if ec.force {
+			log.Info().Msg("No files configured for encryption")
+		} else {
+			log.Info().Msg("All files are encrypted")
+		}
 		return nil
 	}
 

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	"filippo.io/age"
 	"github.com/hay-kot/mmdot/internal/core"
 	"github.com/hay-kot/mmdot/pkgs/fcrypt"
+	"github.com/urfave/cli/v3"
 )
 
 func chdir(t *testing.T, dir string) {
@@ -318,5 +321,212 @@ func Test_ensureGitignored_existingContentWithTrailingNewline(t *testing.T) {
 	want := "*.log\n" + path + "\n"
 	if string(data) != want {
 		t.Errorf(".gitignore content = %q, want %q", string(data), want)
+	}
+}
+
+// runEncryptCmd builds a minimal CLI app and runs the encrypt subcommand with
+// the provided arguments. It returns any error produced by the action.
+func runEncryptCmd(t *testing.T, cfgPath string, args ...string) error {
+	t.Helper()
+	flags := &core.Flags{ConfigFilePath: cfgPath}
+	app := &cli.Command{Name: "mmdot"}
+	NewEncryptCmd(flags).Register(app)
+	argv := append([]string{"mmdot", "encrypt"}, args...)
+	return app.Run(context.Background(), argv)
+}
+
+// writeAgeConfig writes a minimal mmdot.yml that configures one age.files entry.
+// recipientKey is the public age key string (e.g. "age1...").
+func writeAgeConfig(t *testing.T, dir, recipientKey, src, dest string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "mmdot.yml")
+	content := fmt.Sprintf(`version: 2
+age:
+  recipients:
+    - %s
+  files:
+    - src: %s
+      dest: %s
+`, recipientKey, src, dest)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeAgeConfig: %v", err)
+	}
+	return cfgPath
+}
+
+// TestEncryptForce_AgeFile_ExistingNotOverwrittenWithoutForce checks that an
+// existing .age file is preserved when --force is not set.
+func TestEncryptForce_AgeFile_ExistingNotOverwrittenWithoutForce(t *testing.T) {
+	id, recipients := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	plainPath := filepath.Join(tmpDir, "secret.json")
+	agePath := filepath.Join(tmpDir, "secret.json.age")
+
+	// Write plaintext
+	if err := os.WriteFile(plainPath, []byte("sensitive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a stale .age file encrypted to a different recipient so the content
+	// differs from what a fresh encryption would produce.
+	staleID, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate stale identity: %v", err)
+	}
+	if err := fcrypt.EncryptFileKeepSource(plainPath, agePath, []age.Recipient{staleID.Recipient()}); err != nil {
+		t.Fatalf("encrypt stale: %v", err)
+	}
+
+	// Set .age mtime newer than plaintext so the up-to-date check also skips it.
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(agePath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	originalStat, err := os.Stat(agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := writeAgeConfig(t, tmpDir, id.Recipient().String(), "secret.json.age", "secret.json")
+
+	// Without --force the file should be skipped (up-to-date).
+	if err := runEncryptCmd(t, cfgPath); err != nil {
+		t.Fatalf("encrypt without --force returned error: %v", err)
+	}
+
+	afterStat, err := os.Stat(agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !afterStat.ModTime().Equal(originalStat.ModTime()) {
+		t.Error("--force absent: .age file was modified but should have been skipped")
+	}
+
+	// Confirm that decryption with the original identity still succeeds (file untouched).
+	decPath := filepath.Join(tmpDir, "secret-check.json")
+	if err := fcrypt.DecryptFile(agePath, decPath, staleID); err != nil {
+		t.Errorf("decryption with original identity failed after no-force run: %v", err)
+	}
+
+	_ = recipients // satisfy compiler
+}
+
+// TestEncryptForce_AgeFile_ExistingOverwrittenWithForce checks that --force
+// re-encrypts a file even when an up-to-date .age file exists.
+func TestEncryptForce_AgeFile_ExistingOverwrittenWithForce(t *testing.T) {
+	id, _ := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	plainPath := filepath.Join(tmpDir, "secret.json")
+	agePath := filepath.Join(tmpDir, "secret.json.age")
+
+	// Write plaintext
+	if err := os.WriteFile(plainPath, []byte("sensitive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a stale .age file encrypted to a DIFFERENT identity.
+	staleID, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate stale identity: %v", err)
+	}
+	if err := fcrypt.EncryptFileKeepSource(plainPath, agePath, []age.Recipient{staleID.Recipient()}); err != nil {
+		t.Fatalf("encrypt stale: %v", err)
+	}
+
+	// Make .age newer than plaintext so the mtime check would normally skip it.
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(agePath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := writeAgeConfig(t, tmpDir, id.Recipient().String(), "secret.json.age", "secret.json")
+
+	// With --force the file must be re-encrypted.
+	if err := runEncryptCmd(t, cfgPath, "--force"); err != nil {
+		t.Fatalf("encrypt --force returned error: %v", err)
+	}
+
+	// The new .age file should be decryptable with id but NOT with staleID.
+	decOK := filepath.Join(tmpDir, "secret-ok.json")
+	if err := fcrypt.DecryptFile(agePath, decOK, id); err != nil {
+		t.Errorf("decryption with new identity failed after --force: %v", err)
+	}
+
+	decFail := filepath.Join(tmpDir, "secret-fail.json")
+	if err := fcrypt.DecryptFile(agePath, decFail, staleID); err == nil {
+		t.Error("decryption with OLD identity succeeded after --force — file was not re-encrypted")
+	}
+}
+
+// TestEncryptForce_VaultFile_ExistingOverwrittenWithForce checks that --force
+// re-encrypts a vault variable file (variables.var_files with ?vault=true)
+// even when the .age file already exists.
+func TestEncryptForce_VaultFile_ExistingOverwrittenWithForce(t *testing.T) {
+	id, _ := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	chdir(t, tmpDir)
+
+	plainPath := filepath.Join(tmpDir, "vault.yml")
+	agePath := filepath.Join(tmpDir, "vault.yml.age")
+
+	if err := os.WriteFile(plainPath, []byte("secret: value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Encrypt to a different (stale) identity first.
+	staleID, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate stale identity: %v", err)
+	}
+	// Use EncryptFileKeepSource to preserve the plaintext — the vault encrypt path
+	// expects the plaintext to exist alongside the .age file.
+	if err := fcrypt.EncryptFileKeepSource(plainPath, agePath, []age.Recipient{staleID.Recipient()}); err != nil {
+		t.Fatalf("encrypt stale vault: %v", err)
+	}
+
+	cfgContent := fmt.Sprintf(`version: 2
+age:
+  recipients:
+    - %s
+variables:
+  var_files:
+    - vault.yml.age?vault=true
+`, id.Recipient().String())
+	cfgPath := filepath.Join(tmpDir, "mmdot.yml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without --force: stale .age exists → should be skipped, stale identity still decryptable.
+	if err := runEncryptCmd(t, cfgPath); err != nil {
+		t.Fatalf("encrypt without --force returned error: %v", err)
+	}
+	decSkip := filepath.Join(tmpDir, "vault-skip.yml")
+	if err := fcrypt.DecryptFile(agePath, decSkip, staleID); err != nil {
+		t.Errorf("without --force stale identity should still decrypt: %v", err)
+	}
+
+	// With --force: must be re-encrypted to new recipients.
+	if err := runEncryptCmd(t, cfgPath, "--force"); err != nil {
+		t.Fatalf("encrypt --force returned error: %v", err)
+	}
+
+	decOK := filepath.Join(tmpDir, "vault-ok.yml")
+	if err := fcrypt.DecryptFile(agePath, decOK, id); err != nil {
+		t.Errorf("new identity should decrypt after --force: %v", err)
+	}
+
+	decFail := filepath.Join(tmpDir, "vault-fail.yml")
+	if err := fcrypt.DecryptFile(agePath, decFail, staleID); err == nil {
+		t.Error("stale identity still decrypts after --force — vault file was not re-encrypted")
 	}
 }


### PR DESCRIPTION
## Summary

Adds `--force` to `mmdot encrypt` as an escape hatch for recipient drift: when an existing `.age` file was encrypted to a different set of recipients than what's currently configured, `--force` bypasses both the vault-file "already exists" skip and the `age.files` mtime check, unconditionally re-encrypting everything.

`--force --dry-run` lists what would be re-encrypted rather than only unencrypted deltas.