### PR TITLE
fix: re-encrypt vault/.age files when recipient set has changed

### DIFF
--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -16,6 +16,7 @@ import (
 type EncryptCmd struct {
 	coreFlags *core.Flags
 	dryRun    bool
+	force     bool
 }
 
 func NewEncryptCmd(coreFlags *core.Flags) *EncryptCmd {
@@ -47,6 +48,12 @@ corresponding age identity (private key).`,
 					Usage:       "check if files need encryption without encrypting them",
 					Destination: &ec.dryRun,
 				},
+				&cli.BoolFlag{
+					Name:        "force",
+					Aliases:     []string{"f"},
+					Usage:       "re-encrypt all files regardless of mtime or recipient count",
+					Destination: &ec.force,
+				},
 			},
 			Action: ec.encrypt,
 		},
@@ -77,7 +84,16 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// Collect vault files that need encryption
+	// Collect vault files that need encryption.
+	//
+	// A vault file needs (re-)encryption when:
+	//   1. The .age file is missing (new file).
+	//   2. --force is set (unconditional re-encryption).
+	//   3. Recipient drift: the stanza count in the .age file differs from the
+	//      configured recipient count. Age X25519 stanzas carry only the
+	//      ephemeral wrapped key, not the recipient public key, so exact
+	//      matching is impossible without an identity. Stanza count is a
+	//      reliable proxy: age writes exactly one stanza per recipient.
 	vaultFilesToEncrypt := []string{}
 	for _, file := range cfg.EncryptedFiles() {
 		var sourceFile, targetFile string
@@ -90,6 +106,7 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 			targetFile = file + ".age"
 		}
 
+		// Plaintext source must exist to (re-)encrypt.
 		if _, err := os.Stat(sourceFile); err != nil {
 			if os.IsNotExist(err) {
 				log.Debug().Str("file", sourceFile).Msg("Source file doesn't exist, skipping")
@@ -98,20 +115,51 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to stat %s: %w", sourceFile, err)
 		}
 
-		if _, err := os.Stat(targetFile); err == nil {
-			log.Debug().Str("file", targetFile).Msg("Encrypted file already exists, skipping")
+		// Check whether the target .age file exists.
+		if _, err := os.Stat(targetFile); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to stat %s: %w", targetFile, err)
+			}
+			// Target missing — needs first-time encryption.
+			vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
 			continue
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to stat %s: %w", targetFile, err)
 		}
 
-		vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
+		// Target exists. Re-encrypt when --force or recipient drift detected.
+		if ec.force {
+			log.Debug().Str("file", targetFile).Msg("--force: re-encrypting existing vault file")
+			vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
+			continue
+		}
+
+		stanzaCount, err := fcrypt.CountStanzas(targetFile)
+		if err != nil {
+			log.Warn().Err(err).Str("file", targetFile).
+				Msg("Could not count recipient stanzas; re-encrypting to be safe")
+			vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
+			continue
+		}
+
+		if stanzaCount != len(cfg.Age.Recipients) {
+			log.Debug().
+				Str("file", targetFile).
+				Int("stanzas", stanzaCount).
+				Int("configured_recipients", len(cfg.Age.Recipients)).
+				Msg("Recipient drift detected: re-encrypting vault file")
+			vaultFilesToEncrypt = append(vaultFilesToEncrypt, sourceFile)
+			continue
+		}
+
+		log.Debug().Str("file", targetFile).Msg("Encrypted vault file is up-to-date, skipping")
 	}
 
 	// Collect age.files that need encryption.
-	// Only encrypt when:
-	//   1. Plaintext dest exists AND encrypted src does not (new file)
-	//   2. Plaintext dest is newer than encrypted src (modified file)
+	// Encrypt when any of:
+	//   1. Plaintext dest exists AND encrypted src does not (new file).
+	//   2. Plaintext dest is newer than encrypted src (modified file).
+	//   3. --force is set.
+	//   4. Recipient drift: stanza count in the .age file differs from the
+	//      configured recipient count (same heuristic as vault files above).
 	ageFilesToEncrypt := []core.AgeFile{}
 	for _, af := range cfg.Age.Files {
 		destInfo, err := os.Stat(af.Dest)
@@ -126,15 +174,40 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		srcInfo, err := os.Stat(af.Src)
 		if err != nil {
 			if os.IsNotExist(err) {
-				// Encrypted file missing — needs encryption
+				// Encrypted file missing — needs encryption.
 				ageFilesToEncrypt = append(ageFilesToEncrypt, af)
 				continue
 			}
 			return fmt.Errorf("failed to stat %s: %w", af.Src, err)
 		}
 
+		if ec.force {
+			log.Debug().Str("src", af.Src).Msg("--force: re-encrypting existing age file")
+			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+			continue
+		}
+
 		if destInfo.ModTime().After(srcInfo.ModTime()) {
-			// Plaintext is newer than encrypted — needs re-encryption
+			// Plaintext is newer than encrypted — needs re-encryption.
+			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+			continue
+		}
+
+		// Mtime is current; check for recipient drift.
+		stanzaCount, err := fcrypt.CountStanzas(af.Src)
+		if err != nil {
+			log.Warn().Err(err).Str("file", af.Src).
+				Msg("Could not count recipient stanzas; re-encrypting to be safe")
+			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
+			continue
+		}
+
+		if stanzaCount != len(cfg.Age.Recipients) {
+			log.Debug().
+				Str("file", af.Src).
+				Int("stanzas", stanzaCount).
+				Int("configured_recipients", len(cfg.Age.Recipients)).
+				Msg("Recipient drift detected: re-encrypting age file")
 			ageFilesToEncrypt = append(ageFilesToEncrypt, af)
 			continue
 		}

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -297,6 +298,105 @@ func TestEncryptFileKeepSource_RoundTrip(t *testing.T) {
 	got, _ := os.ReadFile(decPath)
 	if string(got) != plaintext {
 		t.Errorf("round-trip failed: got %q, want %q", got, plaintext)
+	}
+}
+
+// TestVaultFileRecipientDrift verifies that a vault .age file encrypted to
+// fewer recipients than configured is flagged for re-encryption.
+// This simulates the production bug where vault.yml.age was encrypted to only
+// the personal recipient while two recipients were configured in mmdot.yml.
+func TestVaultFileRecipientDrift_DetectedByCountStanzas(t *testing.T) {
+	// Generate two identities; encrypt only to the first.
+	id1, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate id1: %v", err)
+	}
+	id2, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate id2: %v", err)
+	}
+	_ = id2 // second recipient — present in config but NOT used for encryption
+
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "vault.yml")
+	encPath := filepath.Join(dir, "vault.yml.age")
+
+	if err := os.WriteFile(plainPath, []byte("secret: value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Encrypt to only one recipient — simulates the stale state.
+	if err := fcrypt.EncryptFile(plainPath, encPath, []age.Recipient{id1.Recipient()}); err != nil {
+		t.Fatalf("EncryptFile (1 recipient): %v", err)
+	}
+
+	// Stanza count should be 1.
+	stanzas, err := fcrypt.CountStanzas(encPath)
+	if err != nil {
+		t.Fatalf("CountStanzas: %v", err)
+	}
+	if stanzas != 1 {
+		t.Fatalf("CountStanzas = %d, want 1", stanzas)
+	}
+
+	// With 2 configured recipients, drift is detected.
+	configuredCount := 2
+	if stanzas == configuredCount {
+		t.Errorf("drift not detected: stanza count %d equals configured %d", stanzas, configuredCount)
+	}
+}
+
+// TestVaultFileRecipientDrift_ReencryptUpdatesStanzas verifies the full
+// re-encrypt cycle: after re-encrypting a drifted vault file to two
+// recipients the stanza count becomes 2.
+func TestVaultFileRecipientDrift_ReencryptUpdatesStanzas(t *testing.T) {
+	id1, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate id1: %v", err)
+	}
+	id2, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate id2: %v", err)
+	}
+
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "vault.yml")
+	encPath := filepath.Join(dir, "vault.yml.age")
+
+	if err := os.WriteFile(plainPath, []byte("secret: value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// First encryption: only one recipient.
+	if err := fcrypt.EncryptFile(plainPath, encPath, []age.Recipient{id1.Recipient()}); err != nil {
+		t.Fatalf("EncryptFile (1 recipient): %v", err)
+	}
+
+	// Drift detected — restore plaintext so we can re-encrypt.
+	// (EncryptFile removes the source; write it back)
+	if err := os.WriteFile(plainPath, []byte("secret: value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-encrypt to both recipients.
+	if err := fcrypt.EncryptFile(plainPath, encPath, []age.Recipient{id1.Recipient(), id2.Recipient()}); err != nil {
+		t.Fatalf("EncryptFile (2 recipients): %v", err)
+	}
+
+	stanzas, err := fcrypt.CountStanzas(encPath)
+	if err != nil {
+		t.Fatalf("CountStanzas after re-encrypt: %v", err)
+	}
+	if stanzas != 2 {
+		t.Errorf("CountStanzas after re-encrypt = %d, want 2", stanzas)
+	}
+
+	// Both identities should now be able to decrypt.
+	for i, id := range []*age.X25519Identity{id1, id2} {
+		outPath := filepath.Join(dir, fmt.Sprintf("restored-%d.yml", i))
+		if err := fcrypt.DecryptFile(encPath, outPath, id); err != nil {
+			t.Errorf("DecryptFile with identity %d: %v", i, err)
+		}
 	}
 }
 

--- a/internal/generator/engine.go
+++ b/internal/generator/engine.go
@@ -151,7 +151,11 @@ func (e *Engine) loadVarsFile(vf core.VarFile, identity age.Identity) (map[strin
 
 			err = fcrypt.DecryptReader(file, buff, identity)
 			if err != nil {
-				return nil, err
+				// Provide an actionable hint: a common cause is that the .age file
+				// was encrypted to a different set of recipients than the identity
+				// currently in use. Running `mmdot encrypt --force` re-encrypts all
+				// vault files from plaintext to the current recipient list.
+				return nil, fmt.Errorf("%w\n  Hint: %s may have been encrypted with different recipients; if the plaintext source is available, run `mmdot encrypt --force` to re-encrypt it", err, encryptedPath)
 			}
 
 			vars := map[string]any{}

--- a/pkgs/fcrypt/stanza_count.go
+++ b/pkgs/fcrypt/stanza_count.go
@@ -1,0 +1,63 @@
+package fcrypt
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"filippo.io/age/armor"
+)
+
+// CountStanzas returns the number of recipient stanzas in an armored .age file.
+//
+// This is used to detect recipient drift: if the stanza count differs from the
+// number of configured recipients the file was encrypted with a different
+// recipient set and should be re-encrypted.
+//
+// Heuristic: X25519 stanzas carry only the ephemeral wrapped key, not the
+// recipient's public key, so exact recipient matching is impossible without the
+// private identity. Stanza count is a practical proxy — one stanza is written
+// per recipient — and lets us catch the common case of adding or removing
+// recipients without requiring the identity to be present.
+func CountStanzas(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	r := armor.NewReader(f)
+	scanner := bufio.NewScanner(r)
+
+	// First line must be the age version intro "age-encryption.org/v1".
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return 0, fmt.Errorf("read age intro for %s: %w", path, err)
+		}
+		return 0, fmt.Errorf("unexpected end of age header in %s", path)
+	}
+
+	count := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "-> "):
+			// Recipient stanza header line.
+			count++
+		case strings.HasPrefix(line, "--- "):
+			// Footer MAC line — header is complete.
+			return count, nil
+		}
+		// Stanza body lines are base64 (chars [A-Za-z0-9+/]) and can never
+		// start with "-> " or "--- ", so no false positives are possible.
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan age header for %s: %w", path, err)
+	}
+
+	// Reached EOF without the footer — treat as malformed but return what we
+	// counted so callers can still make a best-effort decision.
+	return count, nil
+}

--- a/pkgs/fcrypt/stanza_count_test.go
+++ b/pkgs/fcrypt/stanza_count_test.go
@@ -1,0 +1,107 @@
+package fcrypt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+)
+
+func generateIdentities(t *testing.T, n int) ([]*age.X25519Identity, []age.Recipient) {
+	t.Helper()
+	ids := make([]*age.X25519Identity, n)
+	recs := make([]age.Recipient, n)
+	for i := range n {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("generate identity %d: %v", i, err)
+		}
+		ids[i] = id
+		recs[i] = id.Recipient()
+	}
+	return ids, recs
+}
+
+func TestCountStanzas_SingleRecipient(t *testing.T) {
+	_, recs := generateIdentities(t, 1)
+
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "secret.txt")
+	encPath := filepath.Join(dir, "secret.txt.age")
+
+	if err := os.WriteFile(plainPath, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncryptFile(plainPath, encPath, recs); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	got, err := CountStanzas(encPath)
+	if err != nil {
+		t.Fatalf("CountStanzas: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("CountStanzas = %d, want 1", got)
+	}
+}
+
+func TestCountStanzas_MultipleRecipients(t *testing.T) {
+	const n = 3
+	_, recs := generateIdentities(t, n)
+
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "secret.txt")
+	encPath := filepath.Join(dir, "secret.txt.age")
+
+	if err := os.WriteFile(plainPath, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncryptFile(plainPath, encPath, recs); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	got, err := CountStanzas(encPath)
+	if err != nil {
+		t.Fatalf("CountStanzas: %v", err)
+	}
+	if got != n {
+		t.Errorf("CountStanzas = %d, want %d", got, n)
+	}
+}
+
+func TestCountStanzas_FileNotFound(t *testing.T) {
+	_, err := CountStanzas("/nonexistent/path/file.age")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestCountStanzas_TwoRecipients_DetectsDrift(t *testing.T) {
+	// Simulate drift: encrypt to 1 recipient, configured count is 2.
+	_, recs1 := generateIdentities(t, 1)
+
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "vault.yml")
+	encPath := filepath.Join(dir, "vault.yml.age")
+
+	if err := os.WriteFile(plainPath, []byte("key: value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncryptFile(plainPath, encPath, recs1); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	got, err := CountStanzas(encPath)
+	if err != nil {
+		t.Fatalf("CountStanzas: %v", err)
+	}
+
+	configuredRecipients := 2
+	if got == configuredRecipients {
+		t.Errorf("drift not detected: CountStanzas = %d, configured = %d (should differ)", got, configuredRecipients)
+	}
+	if got != 1 {
+		t.Errorf("CountStanzas = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

`mmdot encrypt` skipped existing `.age` files unconditionally, so vault files encrypted to a stale recipient set were never refreshed. On machines holding only a subset of the configured identities this caused `mmdot generate` to fail with `no identity matched any of the recipients`.

The fix counts recipient stanzas in the existing `.age` file (`fcrypt.CountStanzas`) and triggers re-encryption when the count differs from the configured recipient list. A `--force` flag is added as an unconditional escape hatch. The decrypt error in the generator now includes an actionable hint pointing to `mmdot encrypt --force`.