### PR TITLE
feat: improve encryption workflow ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,40 @@ go install github.com/hay-kot/mmdot
 
 ## Usage
 
-TODO
+```bash
+mmdot generate          # render configured templates
+mmdot encrypt           # create/update managed .age files
+mmdot encrypt --dry-run # report files that need encryption or recipient rotation
+mmdot encrypt --force   # re-encrypt all managed .age files with current recipients
+mmdot decrypt           # restore plaintext copies while keeping .age files
+mmdot clean             # remove plaintext copies when .age counterparts exist
+mmdot clean --dry-run   # preview plaintext files that would be removed
+```
+
+### Secret file lifecycle
+
+Vault variable files are configured with `?vault=true` in `variables.var_files`.
+Running `mmdot encrypt` writes `<file>.age` and removes the plaintext vault file.
+Running `mmdot decrypt` restores the plaintext copy and leaves the `.age` file in
+place so it remains ready to commit.
+
+Files configured under `age.files` use explicit encrypted/plaintext paths:
+
+```yaml
+age:
+  identity_file: path/to/private-key.txt
+  recipients:
+    - age1...
+  files:
+    - src: secrets/example.txt.age # encrypted file managed by mmdot
+      dest: ~/.config/example.txt  # plaintext destination
+      perm: "0600"                 # optional permission after decrypt
+```
+
+For `age.files`, `encrypt` reads `dest` and writes `src` while keeping `dest`.
+`decrypt` reads `src` and writes `dest` while keeping `src`.
+
+When the configured recipient count changes, `encrypt` rotates existing managed
+`.age` files so they can be decrypted by the current recipients. Use
+`encrypt --force` when recipients changed but the count stayed the same.
 

--- a/internal/commands/actions.go
+++ b/internal/commands/actions.go
@@ -72,7 +72,7 @@ func expandMacros(code string, macros map[string]string) (string, error) {
 		})
 
 		for _, word := range words {
-			if after, ok :=strings.CutPrefix(word, "@"); ok  {
+			if after, ok := strings.CutPrefix(word, "@"); ok {
 				macroName := after
 				if _, exists := macros[macroName]; !exists {
 					return "", fmt.Errorf("undefined macro: @%s", macroName)

--- a/internal/commands/cmd_brew.go
+++ b/internal/commands/cmd_brew.go
@@ -126,4 +126,3 @@ func (bc *BrewCmd) diff(ctx context.Context, c *cli.Command) error {
 
 	return nil
 }
-

--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -16,6 +16,8 @@ import (
 type EncryptCmd struct {
 	coreFlags *core.Flags
 	dryRun    bool
+	force     bool
+	cleanDry  bool
 }
 
 func NewEncryptCmd(coreFlags *core.Flags) *EncryptCmd {
@@ -47,8 +49,32 @@ corresponding age identity (private key).`,
 					Usage:       "check if files need encryption without encrypting them",
 					Destination: &ec.dryRun,
 				},
+				&cli.BoolFlag{
+					Name:        "force",
+					Usage:       "force re-encryption of every managed .age file with the current recipients (escape hatch for swapped-but-same-count recipients, or when rotation detection misbehaves)",
+					Destination: &ec.force,
+				},
 			},
 			Action: ec.encrypt,
+		},
+		{
+			Name:  "clean",
+			Usage: "remove decrypted plaintext artifacts, keeping .age files intact",
+			Description: `Removes plaintext copies of managed secret files when an
+encrypted .age counterpart exists.
+
+Useful when decommissioning a machine or pruning a local checkout. The
+.age (encrypted) versions are never touched; only the decrypted
+plaintext is removed. Files whose encrypted counterpart is missing are
+left alone so you don't lose data.`,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:        "dry-run",
+					Usage:       "show what would be removed without deleting anything",
+					Destination: &ec.cleanDry,
+				},
+			},
+			Action: ec.clean,
 		},
 		{
 			Name:  "decrypt",
@@ -142,25 +168,38 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		log.Debug().Str("src", af.Src).Str("dest", af.Dest).Msg("Encrypted file is up-to-date, skipping")
 	}
 
+	// Collect existing .age files whose recipient stanza count no longer
+	// matches the configured recipient list (or all of them, when --rotate is
+	// passed). These need to be decrypted and re-encrypted so newly added
+	// keys can read them.
+	filesToRotate, err := ec.collectRotationCandidates(cfg)
+	if err != nil {
+		return err
+	}
+
 	totalToEncrypt := len(vaultFilesToEncrypt) + len(ageFilesToEncrypt)
+	totalWork := totalToEncrypt + len(filesToRotate)
 
 	if ec.dryRun {
-		if totalToEncrypt > 0 {
-			log.Error().Msg("Found unencrypted files:")
+		if totalWork > 0 {
+			log.Error().Msg("Found files needing encryption work:")
 			for _, file := range vaultFilesToEncrypt {
 				log.Error().Str("file", file).Msg("  - vault file needs encryption")
 			}
 			for _, af := range ageFilesToEncrypt {
 				log.Error().Str("dest", af.Dest).Str("src", af.Src).Msg("  - age file needs encryption")
 			}
-			return fmt.Errorf("found %d unencrypted file(s)", totalToEncrypt)
+			for _, file := range filesToRotate {
+				log.Error().Str("file", file).Msg("  - .age file needs recipient rotation")
+			}
+			return fmt.Errorf("found %d file(s) needing encryption work", totalWork)
 		}
-		log.Info().Msg("All files are encrypted")
+		log.Info().Msg("All files are encrypted and up-to-date with current recipients")
 		return nil
 	}
 
-	if totalToEncrypt == 0 {
-		log.Info().Msg("All files are already encrypted")
+	if totalWork == 0 {
+		log.Info().Msg("All files are already encrypted and up-to-date with current recipients")
 		return nil
 	}
 
@@ -171,6 +210,20 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 	recipients, err := fcrypt.LoadPublicKeys(cfg.Age.Recipients)
 	if err != nil {
 		return fmt.Errorf("failed to load public keys: %w", err)
+	}
+
+	// Rotation requires the identity so we can decrypt then re-encrypt.
+	if len(filesToRotate) > 0 {
+		identity, err := cfg.Age.ReadIdentity()
+		if err != nil {
+			return fmt.Errorf("rotation requires age identity: %w", err)
+		}
+		for _, path := range filesToRotate {
+			log.Info().Str("file", path).Msg("Rotating recipients")
+			if err := fcrypt.RecryptFile(path, identity, recipients); err != nil {
+				return fmt.Errorf("rotate %s: %w", path, err)
+			}
+		}
 	}
 
 	// Encrypt vault files
@@ -201,7 +254,129 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 		log.Info().Str("file", af.Src).Msg("Age file encrypted successfully")
 	}
 
-	log.Info().Int("count", totalToEncrypt).Msg("Encryption complete")
+	log.Info().
+		Int("encrypted", totalToEncrypt).
+		Int("rotated", len(filesToRotate)).
+		Msg("Encryption complete")
+	return nil
+}
+
+// collectRotationCandidates returns the list of existing .age files whose
+// recipient stanza count no longer matches the configured recipients (or all
+// existing .age files when --force is set).
+//
+// Stanza counting is a heuristic that catches the common case of adding or
+// removing a recipient. Same-count swaps, or any bug in the heuristic, can
+// be worked around by re-running with --force, which unconditionally
+// re-encrypts every managed .age file.
+func (ec *EncryptCmd) collectRotationCandidates(cfg core.ConfigFile) ([]string, error) {
+	want := len(cfg.Age.Recipients)
+	var candidates []string
+
+	check := func(path string) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if ec.force {
+			candidates = append(candidates, path)
+			return nil
+		}
+		got, err := fcrypt.CountRecipientStanzas(path)
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", path, err)
+		}
+		if got != want {
+			log.Debug().Str("file", path).Int("have", got).Int("want", want).Msg("recipient count mismatch")
+			candidates = append(candidates, path)
+		}
+		return nil
+	}
+
+	for _, vf := range cfg.EncryptedFiles() {
+		path := vf
+		if !strings.HasSuffix(path, ".age") {
+			path += ".age"
+		}
+		if err := check(path); err != nil {
+			return nil, err
+		}
+	}
+	for _, af := range cfg.Age.Files {
+		if err := check(af.Src); err != nil {
+			return nil, err
+		}
+	}
+	return candidates, nil
+}
+
+// clean removes plaintext copies of managed secret files when the encrypted
+// .age counterpart exists. Encrypted files are never touched.
+func (ec *EncryptCmd) clean(ctx context.Context, cmd *cli.Command) error {
+	cfg, err := core.SetupEnv(ec.coreFlags.ConfigFilePath)
+	if err != nil {
+		return err
+	}
+
+	type target struct {
+		label     string
+		plaintext string
+		encrypted string
+	}
+	var targets []target
+
+	for _, vf := range cfg.EncryptedFiles() {
+		plaintext := strings.TrimSuffix(vf, ".age")
+		encrypted := plaintext + ".age"
+		targets = append(targets, target{"vault", plaintext, encrypted})
+	}
+	for _, af := range cfg.Age.Files {
+		targets = append(targets, target{"age file", af.Dest, af.Src})
+	}
+
+	removed := 0
+	for _, t := range targets {
+		if _, err := os.Stat(t.plaintext); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat %s: %w", t.plaintext, err)
+		}
+		if _, err := os.Stat(t.encrypted); err != nil {
+			if os.IsNotExist(err) {
+				log.Warn().
+					Str("plaintext", t.plaintext).
+					Str("encrypted", t.encrypted).
+					Msg("Encrypted counterpart missing; skipping to avoid data loss")
+				continue
+			}
+			return fmt.Errorf("stat %s: %w", t.encrypted, err)
+		}
+
+		if ec.cleanDry {
+			log.Info().Str("type", t.label).Str("file", t.plaintext).Msg("would remove plaintext")
+			removed++
+			continue
+		}
+
+		log.Info().Str("type", t.label).Str("file", t.plaintext).Msg("removing plaintext")
+		if err := os.Remove(t.plaintext); err != nil {
+			return fmt.Errorf("remove %s: %w", t.plaintext, err)
+		}
+		removed++
+	}
+
+	verb := "removed"
+	if ec.cleanDry {
+		verb = "would remove"
+	}
+	log.Info().Int("count", removed).Msgf("Clean complete (%s plaintext file(s))", verb)
 	return nil
 }
 
@@ -252,9 +427,10 @@ func (ec *EncryptCmd) decrypt(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to decrypt %s: %w", sourceFile, err)
 		}
 
-		if err := os.Remove(sourceFile); err != nil {
-			log.Warn().Str("file", sourceFile).Err(err).Msg("Failed to remove encrypted file after decryption")
-		}
+		// Note: the encrypted .age file is intentionally left in place. It's
+		// committed to the repo and removing it here would force users to
+		// re-run `encrypt` after every decrypt. Use `mmdot clean` to drop
+		// plaintext copies when decommissioning a machine.
 
 		decryptedCount++
 		log.Info().Str("file", targetFile).Msg("Vault file decrypted successfully")

--- a/internal/commands/cmd_encrypt.go
+++ b/internal/commands/cmd_encrypt.go
@@ -28,20 +28,17 @@ func (ec *EncryptCmd) Register(app *cli.Command) *cli.Command {
 	cmds := []*cli.Command{
 		{
 			Name:  "encrypt",
-			Usage: "encrypt all secrets files in-place",
-			Description: `Encrypts all configured secret files using age encryption.
-
-Files to encrypt are specified in mmdot.yaml under various sections like:
-- [ssh.secrets] for SSH private keys and configurations
-- Template varsFile references
+			Usage: "encrypt managed secret files",
+			Description: `Encrypts configured secret files using age encryption.
 
 The command will:
-- Use the configured age recipient (public key) for encryption
-- Create .age encrypted versions of the files
-- Skip files that are already encrypted
-- Preserve original files after encryption
+- Create or update .age files for managed secrets
+- Remove plaintext vault variable files after encryption
+- Keep plaintext age.files destinations after encryption
+- Rotate existing .age files when the configured recipient count changes
+- Skip files that are already encrypted and current
 
-Encrypted files use the age format and can only be decrypted with the
+Encrypted files use the age format and can only be decrypted with a
 corresponding age identity (private key).`,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
@@ -51,7 +48,7 @@ corresponding age identity (private key).`,
 				},
 				&cli.BoolFlag{
 					Name:        "force",
-					Usage:       "force re-encryption of every managed .age file with the current recipients (escape hatch for swapped-but-same-count recipients, or when rotation detection misbehaves)",
+					Usage:       "re-encrypt all managed .age files with the current recipients",
 					Destination: &ec.force,
 				},
 			},
@@ -78,17 +75,18 @@ left alone so you don't lose data.`,
 		},
 		{
 			Name:  "decrypt",
-			Usage: "decrypt all secrets files in-place",
-			Description: `Decrypts all configured .age encrypted files.
+			Usage: "decrypt managed secret files",
+			Description: `Decrypts configured .age files.
 
 The command will:
 - Use your configured age identity (private key) for decryption
-- Restore the original unencrypted files
-- Remove the .age encrypted versions after successful decryption
+- Restore plaintext copies of managed secret files
+- Keep the .age encrypted files in place
 - Skip files that are already decrypted
 
-This is typically used when you need to edit secret files or when setting up
-a new machine from encrypted configuration files.`,
+Use this when you need to edit secret files or when setting up a new machine
+from encrypted configuration files. Run 'mmdot clean' to remove plaintext
+copies later.`,
 			Action: ec.decrypt,
 		},
 	}
@@ -169,10 +167,10 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Collect existing .age files whose recipient stanza count no longer
-	// matches the configured recipient list (or all of them, when --rotate is
-	// passed). These need to be decrypted and re-encrypted so newly added
-	// keys can read them.
-	filesToRotate, err := ec.collectRotationCandidates(cfg)
+	// matches the configured recipient list (or all of them, when --force is
+	// passed). Files that will already be rewritten from plaintext are skipped
+	// so dry-run output shows each file once.
+	filesToRotate, err := ec.collectRotationCandidates(cfg, rotationSkipSet(ageFilesToEncrypt))
 	if err != nil {
 		return err
 	}
@@ -266,14 +264,17 @@ func (ec *EncryptCmd) encrypt(ctx context.Context, cmd *cli.Command) error {
 // existing .age files when --force is set).
 //
 // Stanza counting is a heuristic that catches the common case of adding or
-// removing a recipient. Same-count swaps, or any bug in the heuristic, can
-// be worked around by re-running with --force, which unconditionally
-// re-encrypts every managed .age file.
-func (ec *EncryptCmd) collectRotationCandidates(cfg core.ConfigFile) ([]string, error) {
+// removing a recipient. Same-count swaps can be handled by re-running with
+// --force, which re-encrypts managed .age files that are not already being
+// rewritten from plaintext.
+func (ec *EncryptCmd) collectRotationCandidates(cfg core.ConfigFile, skip map[string]struct{}) ([]string, error) {
 	want := len(cfg.Age.Recipients)
 	var candidates []string
 
 	check := func(path string) error {
+		if _, ok := skip[path]; ok {
+			return nil
+		}
 		info, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -314,6 +315,14 @@ func (ec *EncryptCmd) collectRotationCandidates(cfg core.ConfigFile) ([]string, 
 		}
 	}
 	return candidates, nil
+}
+
+func rotationSkipSet(ageFilesToEncrypt []core.AgeFile) map[string]struct{} {
+	skip := make(map[string]struct{}, len(ageFilesToEncrypt))
+	for _, af := range ageFilesToEncrypt {
+		skip[af.Src] = struct{}{}
+	}
+	return skip
 }
 
 // clean removes plaintext copies of managed secret files when the encrypted

--- a/internal/commands/cmd_encrypt_test.go
+++ b/internal/commands/cmd_encrypt_test.go
@@ -109,6 +109,59 @@ func testRecipients(t *testing.T) (*age.X25519Identity, []age.Recipient) {
 	return id, []age.Recipient{id.Recipient()}
 }
 
+func TestCollectRotationCandidates_SkipsFilesAlreadyNeedingEncryption(t *testing.T) {
+	_, recipients := testRecipients(t)
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "secret.json")
+	srcPath := filepath.Join(tmpDir, "secret.age")
+
+	if err := os.WriteFile(destPath, []byte("plaintext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fcrypt.EncryptFileKeepSource(destPath, srcPath, recipients); err != nil {
+		t.Fatal(err)
+	}
+
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(srcPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	af := core.AgeFile{Src: srcPath, Dest: destPath}
+	cfg := core.ConfigFile{
+		Age: core.Age{
+			Recipients: []string{"old", "new"},
+			Files:      []core.AgeFile{af},
+		},
+	}
+
+	candidates, err := (&EncryptCmd{}).collectRotationCandidates(cfg, nil)
+	if err != nil {
+		t.Fatalf("collectRotationCandidates without skip: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates without skip = %v, want one", candidates)
+	}
+
+	candidates, err = (&EncryptCmd{force: true}).collectRotationCandidates(cfg, rotationSkipSet([]core.AgeFile{af}))
+	if err != nil {
+		t.Fatalf("collectRotationCandidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates = %v, want none", candidates)
+	}
+
+	cfg.Age.Recipients = []string{"old", "new", "newer"}
+	candidates, err = (&EncryptCmd{}).collectRotationCandidates(cfg, rotationSkipSet([]core.AgeFile{af}))
+	if err != nil {
+		t.Fatalf("collectRotationCandidates without force: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates without force = %v, want none", candidates)
+	}
+}
+
 func TestAgeFileNeedsEncrypt_NoDest(t *testing.T) {
 	tmpDir := t.TempDir()
 	af := core.AgeFile{

--- a/internal/commands/cmd_hook.go
+++ b/internal/commands/cmd_hook.go
@@ -28,11 +28,11 @@ func (hc *HookCmd) Register(app *cli.Command) *cli.Command {
 			Commands: []*cli.Command{
 				{
 					Name:  "install",
-					Usage: "install git pre-commit hook to check for unencrypted vault files",
-					Description: `Installs a pre-commit hook that prevents commits containing unencrypted vault files.
+					Usage: "install git pre-commit hook to check managed secrets",
+					Description: `Installs a pre-commit hook that prevents commits when managed secrets need encryption work.
 
-The hook will call 'mmdot encrypt --dry-run' before each commit to verify that all vault files
-are properly encrypted with .age extension.
+The hook will call 'mmdot encrypt --dry-run' before each commit to verify that managed
+.age files exist and are current with the configured recipients.
 
 If a pre-commit hook already exists, the mmdot check will be appended to it.`,
 					Action: hc.install,
@@ -83,7 +83,7 @@ func (hc *HookCmd) install(ctx context.Context, cmd *cli.Command) error {
 
 	// Create the mmdot hook section
 	mmdotHook := fmt.Sprintf(`
-# mmdot pre-commit hook - check vault files are encrypted
+# mmdot pre-commit hook - check managed secrets are encrypted
 %s --config="%s" encrypt --dry-run || exit 1
 `, mmdotPath, configPath)
 

--- a/internal/commands/llmtext/config_schema.txt
+++ b/internal/commands/llmtext/config_schema.txt
@@ -14,7 +14,7 @@ variables:
     <key>: <value>
   var_files:
     - path/to/vars.yml
-    - path/to/secret.yml?vault=true  # decrypted with age
+    - path/to/secret.yml?vault=true  # encrypted as path/to/secret.yml.age
 
 # Age encryption configuration
 age:
@@ -22,9 +22,9 @@ age:
     - <age-public-key>
   identity_file: path/to/key.txt
   files:
-    - src: path/to/file
-      dest: path/to/file.age
-      perm: "0600"  # optional
+    - src: path/to/file.age  # encrypted file managed by mmdot
+      dest: path/to/file     # plaintext destination
+      perm: "0600"          # optional permission after decrypt
 
 # Template definitions
 templates:

--- a/internal/core/path_resolver_test.go
+++ b/internal/core/path_resolver_test.go
@@ -55,7 +55,7 @@ func TestPathResolver_Resolve(t *testing.T) {
 			name:      "relative path without config dir",
 			configDir: "",
 			input:     "relative/path",
-			want:      func() string {
+			want: func() string {
 				cwd, _ := os.Getwd()
 				return filepath.Join(cwd, "relative/path")
 			}(),

--- a/pkgs/fcrypt/rotate.go
+++ b/pkgs/fcrypt/rotate.go
@@ -1,0 +1,89 @@
+package fcrypt
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"filippo.io/age"
+	"filippo.io/age/armor"
+)
+
+// CountRecipientStanzas returns the number of recipient stanzas ("-> ...") in
+// the header of an armored age file. This is a cheap proxy for "how many keys
+// can decrypt this file" and is used to detect when the configured recipient
+// list has grown or shrunk since the file was last encrypted.
+func CountRecipientStanzas(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	r := armor.NewReader(f)
+	br := bufio.NewReader(r)
+
+	count := 0
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return 0, fmt.Errorf("unexpected EOF parsing age header in %s", path)
+			}
+			return 0, fmt.Errorf("read age header in %s: %w", path, err)
+		}
+		line = strings.TrimRight(line, "\n")
+
+		switch {
+		case strings.HasPrefix(line, "-> "):
+			count++
+		case strings.HasPrefix(line, "--- "):
+			return count, nil
+		}
+	}
+}
+
+// RecryptFile decrypts an age file into memory and re-encrypts it back to the
+// same path using the supplied recipients. The file is replaced atomically via
+// a temp file + rename.
+func RecryptFile(path string, identity age.Identity, recipients []age.Recipient) (err error) {
+	in, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	var plaintext bytes.Buffer
+	if err := DecryptReader(in, &plaintext, identity); err != nil {
+		return fmt.Errorf("decrypt %s: %w", path, err)
+	}
+	_ = in.Close()
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), ".mmdot-rotate-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpFile.Name())
+		}
+	}()
+
+	if err = EncryptReader(&plaintext, tmpFile, recipients); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("re-encrypt %s: %w", path, err)
+	}
+
+	if err = tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpFile.Name(), path); err != nil {
+		return fmt.Errorf("rename temp file to %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkgs/fcrypt/rotate_test.go
+++ b/pkgs/fcrypt/rotate_test.go
@@ -1,0 +1,87 @@
+package fcrypt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+)
+
+func newIdentities(t *testing.T, n int) ([]*age.X25519Identity, []age.Recipient) {
+	t.Helper()
+	ids := make([]*age.X25519Identity, n)
+	recs := make([]age.Recipient, n)
+	for i := range n {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("generate identity %d: %v", i, err)
+		}
+		ids[i] = id
+		recs[i] = id.Recipient()
+	}
+	return ids, recs
+}
+
+func TestCountRecipientStanzas(t *testing.T) {
+	cases := []int{1, 2, 5}
+	for _, n := range cases {
+		_, recs := newIdentities(t, n)
+		tmpDir := t.TempDir()
+		in := filepath.Join(tmpDir, "p.txt")
+		out := filepath.Join(tmpDir, "p.age")
+		if err := os.WriteFile(in, []byte("hi"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := EncryptFileKeepSource(in, out, recs); err != nil {
+			t.Fatal(err)
+		}
+		got, err := CountRecipientStanzas(out)
+		if err != nil {
+			t.Fatalf("CountRecipientStanzas: %v", err)
+		}
+		if got != n {
+			t.Errorf("count = %d, want %d", got, n)
+		}
+	}
+}
+
+func TestRecryptFile_AddsNewRecipient(t *testing.T) {
+	ids, recs := newIdentities(t, 1)
+	tmpDir := t.TempDir()
+	in := filepath.Join(tmpDir, "p.txt")
+	enc := filepath.Join(tmpDir, "p.age")
+
+	const plaintext = "rotation works"
+	if err := os.WriteFile(in, []byte(plaintext), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncryptFileKeepSource(in, enc, recs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a second recipient and rotate using the original identity.
+	newIDs, _ := newIdentities(t, 1)
+	allRecs := []age.Recipient{recs[0], newIDs[0].Recipient()}
+	if err := RecryptFile(enc, ids[0], allRecs); err != nil {
+		t.Fatalf("RecryptFile: %v", err)
+	}
+
+	count, err := CountRecipientStanzas(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("stanza count after rotation = %d, want 2", count)
+	}
+
+	// New identity must now be able to decrypt.
+	out := filepath.Join(tmpDir, "out.txt")
+	if err := DecryptFile(enc, out, newIDs[0]); err != nil {
+		t.Fatalf("decrypt with new identity: %v", err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != plaintext {
+		t.Errorf("decrypted = %q, want %q", got, plaintext)
+	}
+}


### PR DESCRIPTION
## Summary

The encrypt/decrypt workflow had three annoying behaviors that this PR fixes:

- **Vault decrypt deleted the `.age` file**, forcing a re-encrypt after every edit. Decrypt is now idempotent and leaves both copies in place.
- **Adding a new recipient didn't re-encrypt existing files**, so newly added keys silently couldn't read older secrets. `encrypt` now counts recipient stanzas in each managed `.age` header and auto-rotates mismatches. `--force` is an escape hatch for same-count swaps.
- **No way to clean plaintext copies off a machine.** New `mmdot clean [--dry-run]` removes plaintext for any file whose `.age` counterpart exists; refuses to touch plaintext if the encrypted copy is missing.